### PR TITLE
fix(dependabot): update head ref format for PR listing

### DIFF
--- a/dependabot/pkg/pr/github.go
+++ b/dependabot/pkg/pr/github.go
@@ -133,7 +133,9 @@ func (g *GitHubPRCreator) checkExistingPR(gitRepo *git.Repository, sourceBranch,
 
 	// List open PRs with the same head branch
 	opts := &github.PullRequestListOptions{
-		Head:  sourceBranch,
+		// head ref should contain the organization name
+		// https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests
+		Head:  fmt.Sprintf("%s:%s", gitRepo.Group, sourceBranch),
 		Base:  targetBranch,
 		State: "open",
 	}


### PR DESCRIPTION
Updated the head ref format in the GitHub PR creator to include the organization name, ensuring compatibility with GitHub's API requirements for listing pull requests.

See: https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
