### PR TITLE
fix(dependabot): improve logging and message formatting in notifier

### DIFF
--- a/dependabot/pkg/notice/factory.go
+++ b/dependabot/pkg/notice/factory.go
@@ -32,7 +32,7 @@ func NewNotifier(noticeConfig config.NoticeConfig) (Notifier, error) {
 		if !ok || webhookURL == "" {
 			return nil, fmt.Errorf("webhook_url is required for WeChat Work notifier")
 		}
-		logrus.Debugf("Creating WeChat Work notifier with webhook URL: %s", webhookURL)
+		logrus.Debug("Creating WeChat Work notifier")
 		return NewWeComNotifier(webhookURL), nil
 	case "":
 		// No notification configured

--- a/dependabot/pkg/notice/wecom.go
+++ b/dependabot/pkg/notice/wecom.go
@@ -117,7 +117,7 @@ func (w *WeComNotifier) buildMessage(componentName string, vulnFixResults types.
 	if pr.URL != "" {
 		msg.WriteString("\n**🔗 Pull Request：**\n")
 		msg.WriteString(fmt.Sprintf(" - 标题：%s\n", pr.Title))
-		msg.WriteString(fmt.Sprintf(" - 链接：[查看PR](%s)\n\n", pr.URL))
+		msg.WriteString(fmt.Sprintf(" - 链接：[%s](%s)\n\n", pr.URL, pr.URL))
 	}
 
 	// Fixed vulnerabilities


### PR DESCRIPTION
- Updated the WeChat Work notifier logging to remove the webhook URL from debug output for security reasons.
- Enhanced the message formatting in the WeComNotifier to ensure the pull request link is displayed correctly.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
