### PR TITLE
fix: prevent creating PR when there are no changes

### DIFF
--- a/dependabot/pkg/pipeline/pipeline.go
+++ b/dependabot/pkg/pipeline/pipeline.go
@@ -123,6 +123,9 @@ func (p *Pipeline) Run() error {
 	branchName, err := p.commitChanges(updateSummary)
 	if err != nil {
 		return fmt.Errorf("failed to commit changes: %w", err)
+	} else if branchName == "" {
+		// No changes to commit, skipping PR creation
+		return nil
 	}
 
 	// Execute post-commit script if configured

--- a/dependabot/pkg/pr/github.go
+++ b/dependabot/pkg/pr/github.go
@@ -19,6 +19,7 @@ package pr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/AlaudaDevops/toolbox/dependabot/pkg/config"
@@ -147,6 +148,11 @@ func (g *GitHubPRCreator) checkExistingPR(gitRepo *git.Repository, sourceBranch,
 
 	if len(prs) == 0 {
 		return nil, nil // No existing PR found
+	}
+
+	if prs[0].GetHead().GetRef() != sourceBranch {
+		logrus.Warnf("Warning: existing PR #%d is not for the current branch: %s. It must be the query condition is incorrect: %#v", prs[0].GetNumber(), sourceBranch, opts)
+		return nil, errors.New("existing PR is not for the current branch")
 	}
 
 	return &types.PRInfo{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
