### PR TITLE
fix: remove auto-LGTM logic from /merge and /ready commands

### DIFF
--- a/pr-cli/pkg/handler/handle_merge.go
+++ b/pr-cli/pkg/handler/handle_merge.go
@@ -34,7 +34,7 @@ func (h *PRHandler) HandleMerge(args []string) error {
 	}
 
 	// Validate check runs status
-	if err := h.validateCheckRunsStatus(); err != nil {
+	if err = h.validateCheckRunsStatus(); err != nil {
 		return err
 	}
 
@@ -132,28 +132,11 @@ func (h *PRHandler) validateAndProcessLGTMVotes(userPerm string) (int, map[strin
 		return 0, nil, fmt.Errorf("failed to get LGTM votes: %w", err)
 	}
 
-	// Handle admin/write user direct merge logic
-	validVotes = h.processAdminUserMergeLogic(validVotes, lgtmUsers, userPerm)
-
 	if validVotes < h.config.LGTMThreshold {
 		return 0, nil, h.postNotEnoughLGTMMessage(validVotes)
 	}
 
 	return validVotes, lgtmUsers, nil
-}
-
-// processAdminUserMergeLogic handles the logic for admin/write users to merge directly
-func (h *PRHandler) processAdminUserMergeLogic(validVotes int, lgtmUsers map[string]string, userPerm string) int {
-	if h.prSender != h.config.CommentSender && h.hasLGTMPermission(userPerm) {
-		_, alreadyVoted := lgtmUsers[h.config.CommentSender]
-		if h.config.LGTMThreshold == 1 || (validVotes >= h.config.LGTMThreshold-1 && !alreadyVoted) {
-			if !alreadyVoted {
-				lgtmUsers[h.config.CommentSender] = userPerm
-				validVotes++
-			}
-		}
-	}
-	return validVotes
 }
 
 // postNotEnoughLGTMMessage posts error message when there are not enough LGTM votes


### PR DESCRIPTION
The processAdminUserMergeLogic function was incorrectly auto-adding LGTM votes when users used /merge or /ready commands, treating them as implicit LGTM approvals. This behavior was incorrect as these commands should only trigger merges when sufficient explicit LGTM votes already exist.

Changes:
- Remove processAdminUserMergeLogic function entirely
- /lgtm command continues to work independently via handle_lgtm.go
- /merge and /ready now only check existing LGTM votes without adding new ones

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
