### PR TITLE
WIP: fix(cherrypick): improve PR title format and fix trailing whitespace

### DIFF
--- a/.tekton/pr-manage.yaml
+++ b/.tekton/pr-manage.yaml
@@ -31,6 +31,10 @@ spec:
     # - name: git_auth_secret_key
     #   value: "git-provider-token"
     #
+    # Container image for pr-cli tool (default: registry.alauda.cn:60070/devops/toolbox/pr-cli:latest)
+    # - name: image
+    #   value: "registry.alauda.cn:60070/devops/toolbox/pr-cli:latest"
+    #
     # The /lgtm threshold needed of approvers for a PR to be approved (default: 1)
     # - name: lgtm_threshold
     #   value: "1"

--- a/pr-cli/pkg/handler/handle_cherrypick.go
+++ b/pr-cli/pkg/handler/handle_cherrypick.go
@@ -162,7 +162,7 @@ func (h *PRHandler) performCherryPickWithGitCLI(commits []git.Commit, targetBran
 	branchName := cherryPicker.GetCherryPickBranchName(lastCommit.SHA, targetBranch)
 
 	// Create a PR for the cherry-pick using the platform-specific client
-	title := fmt.Sprintf("[Cherry-pick %d] %s", h.config.PRNum, prInfo.Title)
+	title := fmt.Sprintf("[Cherry-pick #%d] %s", h.config.PRNum, prInfo.Title)
 	body := fmt.Sprintf("Cherry-pick of PR #%d to %s\n\nOriginal PR: #%d\nRequested by: @%s",
 		h.config.PRNum, targetBranch, h.config.PRNum, h.config.CommentSender)
 
@@ -207,7 +207,7 @@ func (h *PRHandler) performCherryPickWithAPI(commits []git.Commit, targetBranch 
 	}
 
 	// Create a PR for the cherry-pick
-	title := fmt.Sprintf("[Cherry-pick] %s", prInfo.Title)
+	title := fmt.Sprintf("[Cherry-pick #%d] %s", h.config.PRNum, prInfo.Title)
 	body := fmt.Sprintf("Cherry-pick of PR #%d to %s\n\nOriginal PR: #%d\nRequested by: @%s",
 		h.config.PRNum, targetBranch, h.config.PRNum, h.config.CommentSender)
 

--- a/pr-cli/pkg/messages/messages.go
+++ b/pr-cli/pkg/messages/messages.go
@@ -287,7 +287,7 @@ You need either:
 
 PR #%d has an unknown state. Cherrypick can be performed on:
 - **Merged PRs** (cherrypick is created immediately)
-- **Open PRs** (cherrypick is scheduled for when the PR merges)  
+- **Open PRs** (cherrypick is scheduled for when the PR merges)
 - **Closed PRs** (cherrypick the last commit)
 
 Current PR state: %s`
@@ -298,7 +298,7 @@ Failed to cherry-pick changes from PR #%d to branch ` + "`%s`" + `:
 * Requested by: @%s
 * Error: ` + "`%s`" + `
 
-*Possible causes:* 
+*Possible causes:*
 * Merge conflicts
 * Branch protection rules
 * Invalid branch name
@@ -310,7 +310,7 @@ Please resolve any issues and try again.`
 
 Successfully cherry-picked changes from PR #%d to branch ` + "`%s`" + `.
 
-*Details:* 
+*Details:*
 * Source PR: #%d
 * Cherry-pick PR: #%d
 * Target Branch: ` + "`%s`" + `


### PR DESCRIPTION
- Add PR number to cherry-pick titles for better identification
- Standardize title format across git CLI and API methods
- Remove trailing whitespace in message templates

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
