### PR TITLE
feat(auth): add separate comment token support for enhanced security

### DIFF
--- a/pr-cli/cmd/options.go
+++ b/pr-cli/cmd/options.go
@@ -56,6 +56,7 @@ func (p *PROption) AddFlags(flags *pflag.FlagSet) {
 	// Platform and authentication configuration
 	flags.StringVar(&p.Config.Platform, "platform", p.Config.Platform, "Git platform (github or gitlab)")
 	flags.StringVar(&p.Config.Token, "token", "", "Git platform API token for authentication")
+	flags.StringVar(&p.Config.CommentToken, "comment-token", "", "Git platform API token for posting comments (optional, falls back to --token)")
 	flags.StringVar(&p.Config.BaseURL, "base-url", "", "API base URL (optional, defaults per platform)")
 	flags.StringVar(&p.Config.Owner, "repo-owner", "", "Repository owner (organization or user)")
 	flags.StringVar(&p.Config.Repo, "repo-name", "", "Repository name")
@@ -128,6 +129,7 @@ func (p *PROption) readAllFromViper() {
 	// Clean up string values by trimming whitespace and newlines
 	p.Config.Platform = strings.TrimSpace(p.Config.Platform)
 	p.Config.Token = strings.TrimSpace(p.Config.Token)
+	p.Config.CommentToken = strings.TrimSpace(p.Config.CommentToken)
 	p.Config.BaseURL = strings.TrimSpace(p.Config.BaseURL)
 	p.Config.Owner = strings.TrimSpace(p.Config.Owner)
 	p.Config.Repo = strings.TrimSpace(p.Config.Repo)

--- a/pr-cli/pipeline/README.md
+++ b/pr-cli/pipeline/README.md
@@ -91,6 +91,8 @@ The Pipeline supports the following configurable parameters:
 | Parameter | Default Value | Description |
 |-----------|---------------|-------------|
 | `git_auth_secret_key` | `git-provider-token` | The key in git_auth_secret that contains the token |
+| `git_comment_auth_secret` | `github-credentials` | Secret containing the token for posting comments |
+| `git_comment_auth_secret_key` | `token` | The key in git_comment_auth_secret that contains the comment token |
 | `image` | `registry.alauda.cn:60070/devops/toolbox/pr-cli:latest` | Container image for pr-cli tool |
 | `lgtm_permissions` | `admin,write,read` | Permission levels required for LGTM, allow read permission for internal repositories |
 | `lgtm_threshold` | `1` | LGTM approval count threshold |
@@ -171,6 +173,12 @@ spec:
     # The key in git_auth_secret that contains the token (default: git-provider-token)
     # - name: git_auth_secret_key
     #   value: "git-provider-token"
+    #
+    # Optional: Separate secret for posting comments (default: github-credentials)
+    # - name: git_comment_auth_secret
+    #   value: "github-credentials"
+    # - name: git_comment_auth_secret_key
+    #   value: "token"
     #
     # Container image for pr-cli tool (default: registry.alauda.cn:60070/devops/toolbox/pr-cli:latest)
     # - name: image

--- a/pr-cli/pipeline/pr-manage.yaml
+++ b/pr-cli/pipeline/pr-manage.yaml
@@ -36,6 +36,10 @@ spec:
       default: "true"
     - name: robot_accounts
       default: "alaudabot,dependabot,renovate,alaudaa-renovate,edge-katanomi-app2,edge-katanomi-app2[bot]"
+    - name: git_comment_auth_secret
+      default: "github-credentials"
+    - name: git_comment_auth_secret_key
+      default: "token"
   tasks:
     - name: pr-merge-management
       displayName: PR Merge & Management Operations
@@ -91,6 +95,12 @@ spec:
                 value: $(params.verbose)
               - name: PR_ROBOT_ACCOUNTS
                 value: $(params.robot_accounts)
+              - name: PR_COMMENT_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: $(params.git_comment_auth_secret)
+                    key: $(params.git_comment_auth_secret_key)
+                    optional: true
   finally:
     # Execute cherry-pick operations in finally block because after PR merge,
     # the pipeline will be cancelled (set to CancelledRunFinally), so these
@@ -141,3 +151,9 @@ spec:
                 value: $(params.verbose)
               - name: PR_POST_MERGE_CHERRY_PICK
                 value: "true"
+              - name: PR_COMMENT_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: $(params.git_comment_auth_secret)
+                    key: $(params.git_comment_auth_secret_key)
+                    optional: true

--- a/pr-cli/pkg/config/config.go
+++ b/pr-cli/pkg/config/config.go
@@ -26,9 +26,10 @@ import (
 // Config holds the configuration for PR CLI operations
 type Config struct {
 	// Platform configuration
-	Platform string `json:"platform" yaml:"platform" mapstructure:"platform"`
-	Token    string `json:"token" yaml:"token" mapstructure:"token"`
-	BaseURL  string `json:"base_url,omitempty" yaml:"base_url,omitempty" mapstructure:"base-url"`
+	Platform     string `json:"platform" yaml:"platform" mapstructure:"platform"`
+	Token        string `json:"token" yaml:"token" mapstructure:"token"`
+	CommentToken string `json:"comment_token,omitempty" yaml:"comment_token,omitempty" mapstructure:"comment-token"`
+	BaseURL      string `json:"base_url,omitempty" yaml:"base_url,omitempty" mapstructure:"base-url"`
 
 	// Repository configuration
 	Owner string `json:"owner" yaml:"owner" mapstructure:"repo-owner"`
@@ -82,6 +83,7 @@ func NewDefaultConfig() *Config {
 func (c *Config) DebugString() string {
 	debugConfig := *c
 	debugConfig.Token = "[REDACTED]"
+	debugConfig.CommentToken = "[REDACTED]"
 
 	data, err := json.MarshalIndent(debugConfig, "", "  ")
 	if err != nil {

--- a/pr-cli/pkg/git/interfaces.go
+++ b/pr-cli/pkg/git/interfaces.go
@@ -137,6 +137,7 @@ type GitClient interface {
 type Config struct {
 	Platform      string // "github" or "gitlab"
 	Token         string
+	CommentToken  string   // Token specifically for posting comments (optional, falls back to Token)
 	BaseURL       string   // API base URL
 	Owner         string   // Repository owner/namespace
 	Repo          string   // Repository name

--- a/pr-cli/pkg/handler/pr_handler.go
+++ b/pr-cli/pkg/handler/pr_handler.go
@@ -40,6 +40,7 @@ func NewPRHandler(logger *logrus.Logger, cfg *config.Config) (*PRHandler, error)
 	clientConfig := &git.Config{
 		Platform:      cfg.Platform,
 		Token:         cfg.Token,
+		CommentToken:  cfg.CommentToken,
 		BaseURL:       cfg.BaseURL,
 		Owner:         cfg.Owner,
 		Repo:          cfg.Repo,


### PR DESCRIPTION
- Add CommentToken field to Config struct for dedicated comment operations
- Support optional --comment-token CLI flag that falls back to main token
- Create separate GitHub client for comment operations when different token provided
- Update Tekton pipeline to support git_comment_auth_secret parameters
- Add comprehensive documentation for new comment token configuration

This enables using different tokens for read/write operations vs comment posting, improving security posture by allowing least-privilege token access patterns.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
