### PR TITLE
fix(handler): support cherry-pick commands with or without hyphen

### DIFF
--- a/pr-cli/pkg/handler/handle_merge.go
+++ b/pr-cli/pkg/handler/handle_merge.go
@@ -236,7 +236,7 @@ func (h *PRHandler) checkForCherryPickComments() bool {
 }
 
 var (
-	cherryPickPattern = regexp.MustCompile(`^/cherry-pick\s+(\S+)`)
+	cherryPickPattern = regexp.MustCompile(`^/cherry-?pick\s+(\S+)`)
 )
 
 // HandlePostMergeCherryPick processes any cherry-pick commands found in PR comments after merge


### PR DESCRIPTION
Update regex pattern to match both /cherry-pick and /cherrypick commands

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
