### PR TITLE
feat(cherrypick): add multi-line command support and pattern extraction

### DIFF
--- a/pr-cli/pkg/cherrypick/patterns.go
+++ b/pr-cli/pkg/cherrypick/patterns.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2025 The AlaudaDevops Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cherrypick
+
+import "regexp"
+
+// Pre-compiled regular expressions for cherry-pick commands to avoid repeated compilation
+// These patterns support both single-line and multiline comments using the (?m) flag
+var (
+	// CherryPickPattern matches /cherry-pick or /cherrypick command with target branch at the start of a line
+	CherryPickPattern = regexp.MustCompile(`(?m)^/cherry-?pick\s+(\S+)`)
+)

--- a/pr-cli/pkg/cherrypick/patterns_test.go
+++ b/pr-cli/pkg/cherrypick/patterns_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025 The AlaudaDevops Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cherrypick
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/AlaudaDevops/toolbox/pr-cli/pkg/comment"
+)
+
+func TestCherryPickWithMultiLineCommands(t *testing.T) {
+	tests := []struct {
+		name             string
+		commentBody      string
+		expectedBranches []string
+	}{
+		{
+			name:             "Single cherry-pick command",
+			commentBody:      "/cherry-pick release-1.0",
+			expectedBranches: []string{"release-1.0"},
+		},
+		{
+			name: "Multi-line comment with LGTM and cherry-pick",
+			commentBody: `/lgtm
+/cherry-pick release-1.0`,
+			expectedBranches: []string{"release-1.0"},
+		},
+		{
+			name: "Multi-line comment with multiple cherry-picks",
+			commentBody: `/lgtm
+/cherry-pick release-1.0
+/cherrypick hotfix-branch`,
+			expectedBranches: []string{"release-1.0", "hotfix-branch"},
+		},
+		{
+			name: "Cherry-pick mixed with other commands",
+			commentBody: `/assign user1
+/cherry-pick release-1.0
+/merge`,
+			expectedBranches: []string{"release-1.0"},
+		},
+		{
+			name: "No cherry-pick commands",
+			commentBody: `/lgtm
+/merge
+/assign user1`,
+			expectedBranches: []string{},
+		},
+		{
+			name: "Cherry-pick with text around it",
+			commentBody: `This looks good to me!
+/lgtm
+/cherry-pick release-1.0
+Thanks for the fix!`,
+			expectedBranches: []string{"release-1.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Split the comment into command lines
+			commandLines := comment.SplitCommandLines(tt.commentBody)
+
+			// Find all cherry-pick commands
+			var foundBranches []string
+			for _, cmdLine := range commandLines {
+				matches := CherryPickPattern.FindStringSubmatch(cmdLine)
+				if len(matches) > 1 {
+					foundBranches = append(foundBranches, matches[1])
+				}
+			}
+
+			// Verify the results
+			if len(foundBranches) != len(tt.expectedBranches) {
+				t.Errorf("Expected %d cherry-pick commands, got %d. Found: %v, Expected: %v",
+					len(tt.expectedBranches), len(foundBranches), foundBranches, tt.expectedBranches)
+				return
+			}
+
+			// Check each expected branch is found
+			for _, expectedBranch := range tt.expectedBranches {
+				if slices.Contains(foundBranches, expectedBranch) {
+					continue
+				}
+				t.Errorf("Expected to find cherry-pick command for branch %q, but it was not found. Found: %v",
+					expectedBranch, foundBranches)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add cherrypick package with pattern matching functionality
- Support both /cherry-pick and /cherrypick command variations
- Handle multi-line comments with command extraction
- Add comprehensive test coverage for pattern matching
- Refactor merge handler to use new cherrypick patterns
- Enable processing multiple cherry-pick commands per comment

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!--
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)!

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
