### PR TITLE
fix(roadmap-planner): serve Vite assets/ and 404 missing files

### DIFF
--- a/roadmap-planner/backend/internal/api/routes.go
+++ b/roadmap-planner/backend/internal/api/routes.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/AlaudaDevops/toolbox/roadmap-planner/backend/internal/api/handlers"
 	"github.com/AlaudaDevops/toolbox/roadmap-planner/backend/internal/api/middleware"
@@ -95,24 +96,33 @@ func NewRouter(cfg *config.Config) *gin.Engine {
 
 	// Check if static files directory exists
 	if _, err := os.Stat(staticPath); err == nil {
-		// Serve static assets
+		// Serve hashed static asset bundles. Vite outputs to `assets/`;
+		// CRA used `static/`. Register both so a Dockerfile that switches
+		// build tools doesn't need a backend change.
+		router.Static("/assets", filepath.Join(staticPath, "assets"))
 		router.Static("/static", filepath.Join(staticPath, "static"))
 
-		// Serve other static files (manifest.json, etc.)
+		// Top-level static files
 		router.StaticFile("/manifest.json", filepath.Join(staticPath, "manifest.json"))
 		router.StaticFile("/asset-manifest.json", filepath.Join(staticPath, "asset-manifest.json"))
+		if _, err := os.Stat(filepath.Join(staticPath, "favicon.ico")); err == nil {
+			router.StaticFile("/favicon.ico", filepath.Join(staticPath, "favicon.ico"))
+		}
 
-		// Serve index.html for all non-API routes (SPA routing)
+		// SPA fallback. Returns the HTML shell for page-like requests so
+		// react-router (or similar) can take over. Returns 404 for missing
+		// API routes and missing asset-shaped requests (anything with a
+		// file extension) instead of silently serving HTML — that was
+		// masking the missing /assets/* route in v2.
 		router.NoRoute(func(c *gin.Context) {
-			// Don't serve index.html for API routes
-			if c.Request.URL.Path != "/" &&
-				c.Request.URL.Path != "/health" &&
-				!gin.IsDebugging() {
-				// For API routes, return 404
-				if len(c.Request.URL.Path) > 4 && c.Request.URL.Path[:4] == "/api" {
-					c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
-					return
-				}
+			p := c.Request.URL.Path
+			if strings.HasPrefix(p, "/api/") {
+				c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+				return
+			}
+			if filepath.Ext(p) != "" {
+				c.Status(http.StatusNotFound)
+				return
 			}
 			c.File(filepath.Join(staticPath, "index.html"))
 		})


### PR DESCRIPTION
## Summary

The Vite migration in #171 changed the build output layout from CRA's `static/` to Vite's `assets/`, but the Go backend's static-file router still only served `/static/*`. Every `/assets/*.js` and `/assets/*.css` request fell through to the SPA fallback and returned the **HTML shell** (HTTP 200, Content-Type: text/html), so the browser parsed the HTML as JavaScript, the React app never bootstrapped, and the deployed page rendered blank.

## What changed

In [`backend/internal/api/routes.go`](https://github.com/AlaudaDevops/toolbox/blob/8b2e498/roadmap-planner/backend/internal/api/routes.go#L97-L131):

- Register `/assets` (Vite output) alongside the existing `/static` (CRA legacy) so a Dockerfile that flips build tools doesn't need another backend change.
- Register `/favicon.ico` when one is present in the build.
- Tighten the SPA fallback: requests with a file extension (`.js`, `.css`, `.ico`, `.png`, `.json`, …) now return **404** instead of HTML. That's what masked this bug — without honest 404s, the next similar misconfiguration will be just as silent.

## Verified

- `go vet ./...` clean
- `go build ./cmd/server` succeeds
- No existing tests broken

## Live evidence

Reproduced on https://devops-road.alaudatech.net/ after deploying `v0.2.0-gc1e6208`: every asset request to `/assets/index-*.js` returned the same 1261-byte HTML shell instead of the JS bundle. The fix is required to land before the next image rebuild can recover the deployment.

## Test plan

- [ ] Once merged, wait for the Tekton image build, bump the `roadmap-planner` Deployment in `gitlab-ce.alauda.cn/devops/edge` to the new tag, and confirm https://devops-road.alaudatech.net/ renders the login page.
- [ ] Verify `/api/auth/status` still returns 401 unauthenticated (regression check on the 404-for-API-routes branch).
- [ ] Verify `curl -I https://.../some-missing.js` returns 404 (regression check on the new ext-based 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)