### PR TITLE
feat(roadmap-planner): 3-tab Team Analytics + GitHub repo wildcard

### DIFF
--- a/roadmap-planner/backend/cmd/server/main.go
+++ b/roadmap-planner/backend/cmd/server/main.go
@@ -205,9 +205,12 @@ func initTeamAnalytics(ctx context.Context, router *gin.Engine, cfg *config.Conf
 		zap.Int("backfill_days", cfg.Storage.BackfillDays))
 
 	service := contributions.NewService(store)
+	pillarMap := contributions.NewPillarMap(cfg.TeamAnalytics)
+	service.SetPillarMap(pillarMap)
 	aggregator := contributions.NewAggregator(store)
 	api.AddContributionsRoutes(router, store, service, aggregator)
-	logger.Info("Contributions API routes added")
+	logger.Info("Contributions API routes added",
+		zap.Int("pillars_configured", len(pillarMap.Order())))
 
 	// Optional Jira sync goroutine.
 	//

--- a/roadmap-planner/backend/cmd/server/main.go
+++ b/roadmap-planner/backend/cmd/server/main.go
@@ -355,12 +355,21 @@ func openStore(cfg config.Storage) (storage.Store, error) {
 func parseRepos(specs []string) []ghclient.RepoConfig {
 	out := make([]ghclient.RepoConfig, 0, len(specs))
 	for _, raw := range specs {
-		// "owner/name" or "owner/name:component"
+		// "owner/name", "owner/name:component", or "owner/*" for
+		// wildcard expansion (resolved at Sync time against
+		// /orgs/{owner}/repos). Component labels are not allowed on
+		// wildcard specs — write `OWNER/NAME:component` separately if
+		// you want a per-repo label override.
 		spec, comp, _ := strings.Cut(raw, ":")
 		owner, name, ok := strings.Cut(spec, "/")
 		if !ok || owner == "" || name == "" {
 			logger.Warn("malformed github repo spec, skipping", zap.String("spec", raw))
 			continue
+		}
+		if name == "*" && comp != "" {
+			logger.Warn("github repo wildcard cannot carry a component label, dropping label",
+				zap.String("spec", raw))
+			comp = ""
 		}
 		out = append(out, ghclient.RepoConfig{
 			Owner: owner, Name: name, Component: comp,

--- a/roadmap-planner/backend/config.example.yaml
+++ b/roadmap-planner/backend/config.example.yaml
@@ -108,6 +108,12 @@ github:
   repos:
     - "AlaudaDevops/toolbox"
     # - "owner/name:component"  # optional component label per repo
+    # - "AlaudaDevops/*"        # wildcard: expand to every active,
+    #                           # non-fork repo in the org. Resolved
+    #                           # at sync time, cached 24h. Works
+    #                           # alongside explicit entries — an
+    #                           # explicit OWNER/NAME:component still
+    #                           # keeps its component label.
 
   # Auth — App is recommended for production. Token is fine for local
   # dev or one-off scripts. App wins when both are set.

--- a/roadmap-planner/backend/go.mod
+++ b/roadmap-planner/backend/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/trivago/tgo v1.0.7
 	go.uber.org/zap v1.27.1
+	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.50.0
 )
 
@@ -73,7 +74,6 @@ require (
 	golang.org/x/text v0.31.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.72.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/roadmap-planner/backend/internal/api/handlers/contributions.go
+++ b/roadmap-planner/backend/internal/api/handlers/contributions.go
@@ -243,7 +243,12 @@ func (h *ContributionsHandler) UpdateMember(c *gin.Context) {
 		existing.PillarID = strings.TrimSpace(*req.PillarID)
 	}
 
-	if err := h.store.UpsertMember(c.Request.Context(), *existing); err != nil {
+	// Literal-overwrite on these three fields — UpsertMember's COALESCE
+	// semantics (which protect operator edits from being clobbered by
+	// the Jira sync) would otherwise turn an explicit clear ("github_login": "")
+	// into a no-op. SetMemberIdentity bypasses that and writes verbatim.
+	if err := h.store.SetMemberIdentity(c.Request.Context(), id,
+		existing.DisplayName, existing.GitHubLogin, existing.PillarID); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/roadmap-planner/backend/internal/api/handlers/contributions.go
+++ b/roadmap-planner/backend/internal/api/handlers/contributions.go
@@ -134,7 +134,58 @@ func (h *ContributionsHandler) MemberDetail(c *gin.Context) {
 	if info != nil {
 		resp["info"] = info
 	}
+	// Best-effort: components-touched + current sprint. We surface the
+	// error in logs but do not fail the whole response — the profile
+	// page is useful even without these extras.
+	if extras, xErr := h.service.MemberExtras(c.Request.Context(), id, q); xErr == nil {
+		resp["components_touched"] = extras.ComponentsTouched
+		if extras.Sprint != nil {
+			resp["sprint"] = extras.Sprint
+		}
+	} else {
+		logger.Warn("member extras failed", zap.String("member_id", id), zap.Error(xErr))
+	}
 	c.JSON(http.StatusOK, resp)
+}
+
+// NetworkDensity — GET /api/contributions/network?from=&to=
+//
+// Aggregate review-health stats for the Team Overview "Review network
+// density" panel: orphan rate, first-review p50/p90, cross-pillar
+// review percentage.
+func (h *ContributionsHandler) NetworkDensity(c *gin.Context) {
+	q, err := h.parseQuery(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	out, err := h.service.NetworkDensity(c.Request.Context(), q)
+	if err != nil {
+		logger.Error("network density failed", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+// PillarThroughput — GET /api/contributions/pillars?from=&to=
+//
+// Returns weekly PR-merged + Jira-done counts grouped by member.pillar.
+// Members without a pillar are surfaced under the synthetic "Unassigned"
+// label so the dashboard can hint that pillars need to be set.
+func (h *ContributionsHandler) PillarThroughput(c *gin.Context) {
+	q, err := h.parseQuery(c)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	rows, err := h.service.PillarThroughput(c.Request.Context(), q)
+	if err != nil {
+		logger.Error("pillar throughput failed", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"buckets": rows, "from": q.From, "to": q.To})
 }
 
 // UpdateMember — PATCH /api/contributions/members/:id

--- a/roadmap-planner/backend/internal/api/handlers/contributions.go
+++ b/roadmap-planner/backend/internal/api/handlers/contributions.go
@@ -170,9 +170,13 @@ func (h *ContributionsHandler) NetworkDensity(c *gin.Context) {
 
 // PillarThroughput — GET /api/contributions/pillars?from=&to=
 //
-// Returns weekly PR-merged + Jira-done counts grouped by member.pillar.
-// Members without a pillar are surfaced under the synthetic "Unassigned"
-// label so the dashboard can hint that pillars need to be set.
+// Returns weekly PR-merged + Jira-done counts grouped by pillar. Pillar
+// attribution is per-PR (via repo→pillars) and per-issue (via Jira
+// component → pillars), driven by the team_analytics.pillars config.
+// PRs / issues that don't match any configured pillar fall under the
+// synthetic "Unassigned" key. The `pillars` field in the response gives
+// the configured display order so the frontend can render zero-stack
+// pillars even when they had no activity.
 func (h *ContributionsHandler) PillarThroughput(c *gin.Context) {
 	q, err := h.parseQuery(c)
 	if err != nil {
@@ -185,7 +189,15 @@ func (h *ContributionsHandler) PillarThroughput(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"buckets": rows, "from": q.From, "to": q.To})
+	pm := h.service.PillarMap()
+	c.JSON(http.StatusOK, gin.H{
+		"buckets":    rows,
+		"from":       q.From,
+		"to":         q.To,
+		"pillars":    pm.PublicConfig(),
+		"order":      pm.Order(),
+		"configured": pm.Configured(),
+	})
 }
 
 // UpdateMember — PATCH /api/contributions/members/:id

--- a/roadmap-planner/backend/internal/api/routes.go
+++ b/roadmap-planner/backend/internal/api/routes.go
@@ -142,8 +142,10 @@ func NewRouter(cfg *config.Config) *gin.Engine {
 //
 //	GET   /api/contributions/members         — directory of members
 //	GET   /api/contributions/team            — team-overview rollups
-//	GET   /api/contributions/members/:id     — single member detail
+//	GET   /api/contributions/members/:id     — single member detail (+ components, sprint)
 //	PATCH /api/contributions/members/:id     — update editable identity fields
+//	GET   /api/contributions/network         — review-network density panel
+//	GET   /api/contributions/pillars         — pillar throughput stack
 //	GET   /api/contributions/status          — last-sync timestamps
 func AddContributionsRoutes(router *gin.Engine, store storage.Store, service *contributions.Service, aggregator *contributions.Aggregator) {
 	if store == nil || service == nil {
@@ -158,6 +160,8 @@ func AddContributionsRoutes(router *gin.Engine, store storage.Store, service *co
 		g.GET("/team", h.TeamOverview)
 		g.GET("/members/:id", h.MemberDetail)
 		g.PATCH("/members/:id", h.UpdateMember)
+		g.GET("/network", h.NetworkDensity)
+		g.GET("/pillars", h.PillarThroughput)
 		g.GET("/status", h.CollectorStatus)
 	}
 }

--- a/roadmap-planner/backend/internal/config/config.go
+++ b/roadmap-planner/backend/internal/config/config.go
@@ -25,14 +25,46 @@ import (
 
 // Config represents the application configuration
 type Config struct {
-	Debug   bool    `mapstructure:"debug"`
-	Logger  Logger  `mapstructure:"logger"`
-	Jira    Jira    `mapstructure:"jira"`
-	Server  Server  `mapstructure:"server"`
-	Cache   Cache   `mapstructure:"cache"`
-	Metrics Metrics `mapstructure:"metrics"`
-	Storage Storage `mapstructure:"storage"`
-	GitHub  GitHub  `mapstructure:"github"`
+	Debug         bool          `mapstructure:"debug"`
+	Logger        Logger        `mapstructure:"logger"`
+	Jira          Jira          `mapstructure:"jira"`
+	Server        Server        `mapstructure:"server"`
+	Cache         Cache         `mapstructure:"cache"`
+	Metrics       Metrics       `mapstructure:"metrics"`
+	Storage       Storage       `mapstructure:"storage"`
+	GitHub        GitHub        `mapstructure:"github"`
+	TeamAnalytics TeamAnalytics `mapstructure:"team_analytics"`
+}
+
+// TeamAnalytics holds the pillar attribution map used by /api/contributions/pillars
+// (and the slice explorer's pillar axis).
+//
+// Layout: pillar name → list of repo globs and Jira component names that
+// belong to it. A single repo or component MAY appear under several pillars;
+// each appearance credits the corresponding pillar independently when a PR
+// or issue lands. Member-level totals stay independent of this mapping —
+// pillar attribution is per-PR / per-issue, not per-member.
+//
+// Repo entries support glob (`*`) wildcards. Owner case-insensitive match.
+// Jira component names match exactly (case-insensitive).
+//
+// Example:
+//
+//	team_analytics:
+//	  pillars:
+//	    "CI/CD":
+//	      repos: ["alaudadevops/tektoncd-*", "alaudadevops/helm*"]
+//	      components: ["Tekton"]
+//	    "Tool Deployment":
+//	      repos: ["alaudadevops/harbor*", "alaudadevops/helm*"]
+type TeamAnalytics struct {
+	Pillars map[string]PillarMapping `mapstructure:"pillars"`
+}
+
+// PillarMapping is one bucket inside TeamAnalytics.Pillars.
+type PillarMapping struct {
+	Repos      []string `mapstructure:"repos"`
+	Components []string `mapstructure:"components"`
 }
 
 // Storage configures the durable team-analytics store.

--- a/roadmap-planner/backend/internal/config/config.go
+++ b/roadmap-planner/backend/internal/config/config.go
@@ -18,9 +18,11 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
 
 // Config represents the application configuration
@@ -58,13 +60,13 @@ type Config struct {
 //	    "Tool Deployment":
 //	      repos: ["alaudadevops/harbor*", "alaudadevops/helm*"]
 type TeamAnalytics struct {
-	Pillars map[string]PillarMapping `mapstructure:"pillars"`
+	Pillars map[string]PillarMapping `mapstructure:"pillars" yaml:"pillars"`
 }
 
 // PillarMapping is one bucket inside TeamAnalytics.Pillars.
 type PillarMapping struct {
-	Repos      []string `mapstructure:"repos"`
-	Components []string `mapstructure:"components"`
+	Repos      []string `mapstructure:"repos" yaml:"repos"`
+	Components []string `mapstructure:"components" yaml:"components"`
 }
 
 // Storage configures the durable team-analytics store.
@@ -386,6 +388,21 @@ func Load() (*Config, error) {
 	var config Config
 	if err := viper.Unmarshal(&config); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+	}
+
+	// Viper lowercases map keys on unmarshal — that destroys pillar
+	// names like "CI/CD" or "DevOps - RFEs & NFR". Re-parse the
+	// team_analytics block straight from the config file so the
+	// configured names round-trip exactly.
+	if path := viper.ConfigFileUsed(); path != "" {
+		if raw, err := os.ReadFile(path); err == nil {
+			var preserve struct {
+				TeamAnalytics TeamAnalytics `yaml:"team_analytics"`
+			}
+			if uerr := yaml.Unmarshal(raw, &preserve); uerr == nil && len(preserve.TeamAnalytics.Pillars) > 0 {
+				config.TeamAnalytics = preserve.TeamAnalytics
+			}
+		}
 	}
 
 	return &config, nil

--- a/roadmap-planner/backend/internal/contributions/pillar_mapping.go
+++ b/roadmap-planner/backend/internal/contributions/pillar_mapping.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2024 The AlaudaDevops Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+// Pillar attribution map.
+//
+// /api/contributions/pillars rolls weekly PR-merged + Jira-done counts up
+// by pillar. The mapping that says "this PR belongs to CI/CD, that issue
+// also belongs to Tool Deployment" lives in config (TeamAnalytics.Pillars)
+// rather than in Jira, because the DEVOPS Jira project's pillar issues
+// don't carry a component label and we want predictable attribution
+// without waiting on a Jira data fix.
+//
+// Multi-attribution: a single PR or issue can land under N pillars.
+// Each pillar gets +1 in its weekly bucket — there is no proportional
+// split. Per-member totals are unaffected (they aggregate from
+// member_week_metrics which is a flat per-member rollup).
+
+package contributions
+
+import (
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/AlaudaDevops/toolbox/roadmap-planner/backend/internal/config"
+)
+
+// PillarMap is the in-memory form of config.TeamAnalytics. It pre-compiles
+// the lookups for hot-path queries.
+type PillarMap struct {
+	// repo glob → list of pillars that claim it (lowercased glob keys).
+	repoGlobs []repoGlob
+	// component name (lowercased) → pillars.
+	componentToPillars map[string][]string
+	// stable pillar order (config map is unordered) — preserves the YAML
+	// declaration order for chart legends. Empty when the user did not
+	// configure any pillars.
+	order []string
+}
+
+type repoGlob struct {
+	pattern string // lowercased glob
+	pillars []string
+}
+
+// NewPillarMap builds the attribution map from the parsed config block.
+// Returns a non-nil but empty *PillarMap when the config is empty so
+// callers can use it without nil-guarding.
+func NewPillarMap(cfg config.TeamAnalytics) *PillarMap {
+	pm := &PillarMap{
+		componentToPillars: map[string][]string{},
+	}
+	if len(cfg.Pillars) == 0 {
+		return pm
+	}
+	// Stable order: alphabetical for now. Viper does not preserve YAML
+	// map order on unmarshal, so the chart legend is alphabetical too.
+	for name := range cfg.Pillars {
+		pm.order = append(pm.order, name)
+	}
+	sort.Strings(pm.order)
+	for _, name := range pm.order {
+		mp := cfg.Pillars[name]
+		for _, r := range mp.Repos {
+			r = strings.ToLower(strings.TrimSpace(r))
+			if r == "" {
+				continue
+			}
+			pm.repoGlobs = append(pm.repoGlobs, repoGlob{pattern: r, pillars: []string{name}})
+		}
+		for _, c := range mp.Components {
+			c = strings.ToLower(strings.TrimSpace(c))
+			if c == "" {
+				continue
+			}
+			pm.componentToPillars[c] = append(pm.componentToPillars[c], name)
+		}
+	}
+	pm.repoGlobs = compactRepoGlobs(pm.repoGlobs)
+	return pm
+}
+
+// Configured reports whether any pillar mapping is loaded.
+func (p *PillarMap) Configured() bool {
+	return p != nil && (len(p.repoGlobs) > 0 || len(p.componentToPillars) > 0)
+}
+
+// Order returns the configured pillar names in display order. The
+// caller can use it to render the chart legend so empty pillars still
+// appear as zero-stacks.
+func (p *PillarMap) Order() []string {
+	if p == nil {
+		return nil
+	}
+	out := make([]string, len(p.order))
+	copy(out, p.order)
+	return out
+}
+
+// PillarConfigEntry is the wire-friendly view of one pillar's mapping
+// (used in the /pillars response so the frontend can derive a member's
+// pillar set from the same component list the backend uses).
+type PillarConfigEntry struct {
+	Name       string   `json:"name"`
+	Components []string `json:"components,omitempty"`
+}
+
+// PublicConfig returns the configured pillars in display order, with
+// component lists. Repo globs are intentionally omitted — the frontend
+// does not need them, and they would only encourage drift between
+// frontend and backend matching logic.
+func (p *PillarMap) PublicConfig() []PillarConfigEntry {
+	if p == nil {
+		return nil
+	}
+	out := make([]PillarConfigEntry, 0, len(p.order))
+	for _, name := range p.order {
+		entry := PillarConfigEntry{Name: name}
+		for comp, pillars := range p.componentToPillars {
+			for _, pl := range pillars {
+				if pl == name {
+					entry.Components = append(entry.Components, comp)
+					break
+				}
+			}
+		}
+		sort.Strings(entry.Components)
+		out = append(out, entry)
+	}
+	return out
+}
+
+// PillarsForRepo returns every pillar that claims `owner/name`. Empty
+// slice means "no mapping" — the caller decides whether to bucket those
+// PRs under "Unassigned" or skip them.
+func (p *PillarMap) PillarsForRepo(fullName string) []string {
+	if p == nil || len(p.repoGlobs) == 0 {
+		return nil
+	}
+	low := strings.ToLower(strings.TrimSpace(fullName))
+	if low == "" {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, g := range p.repoGlobs {
+		ok, err := path.Match(g.pattern, low)
+		if err != nil || !ok {
+			continue
+		}
+		for _, pl := range g.pillars {
+			if !seen[pl] {
+				seen[pl] = true
+				out = append(out, pl)
+			}
+		}
+	}
+	return out
+}
+
+// PillarsForComponents returns every pillar that claims any of the
+// listed Jira component names. Comparison is case-insensitive.
+func (p *PillarMap) PillarsForComponents(components []string) []string {
+	if p == nil || len(p.componentToPillars) == 0 || len(components) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, c := range components {
+		key := strings.ToLower(strings.TrimSpace(c))
+		if key == "" {
+			continue
+		}
+		for _, pl := range p.componentToPillars[key] {
+			if !seen[pl] {
+				seen[pl] = true
+				out = append(out, pl)
+			}
+		}
+	}
+	return out
+}
+
+// compactRepoGlobs merges duplicate pattern entries so we don't double-count
+// when the same glob appears under multiple pillars.
+func compactRepoGlobs(in []repoGlob) []repoGlob {
+	if len(in) <= 1 {
+		return in
+	}
+	idx := map[string]int{}
+	var out []repoGlob
+	for _, g := range in {
+		if at, ok := idx[g.pattern]; ok {
+			seen := map[string]bool{}
+			for _, p := range out[at].pillars {
+				seen[p] = true
+			}
+			for _, p := range g.pillars {
+				if !seen[p] {
+					out[at].pillars = append(out[at].pillars, p)
+				}
+			}
+			continue
+		}
+		idx[g.pattern] = len(out)
+		out = append(out, g)
+	}
+	return out
+}

--- a/roadmap-planner/backend/internal/contributions/pillar_mapping_test.go
+++ b/roadmap-planner/backend/internal/contributions/pillar_mapping_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2024 The AlaudaDevops Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package contributions_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/AlaudaDevops/toolbox/roadmap-planner/backend/internal/config"
+	"github.com/AlaudaDevops/toolbox/roadmap-planner/backend/internal/contributions"
+)
+
+func TestPillarMap_RepoMatchSinglePillar(t *testing.T) {
+	pm := contributions.NewPillarMap(config.TeamAnalytics{
+		Pillars: map[string]config.PillarMapping{
+			"CI/CD": {Repos: []string{"alaudadevops/tektoncd-*"}},
+		},
+	})
+	got := pm.PillarsForRepo("AlaudaDevops/tektoncd-cli")
+	if !equalUnordered(got, []string{"CI/CD"}) {
+		t.Fatalf("want [CI/CD], got %v", got)
+	}
+	if got := pm.PillarsForRepo("AlaudaDevops/unrelated"); len(got) != 0 {
+		t.Fatalf("want empty, got %v", got)
+	}
+}
+
+func TestPillarMap_RepoMatchMultiPillar(t *testing.T) {
+	pm := contributions.NewPillarMap(config.TeamAnalytics{
+		Pillars: map[string]config.PillarMapping{
+			"CI/CD":           {Repos: []string{"alaudadevops/helm*"}},
+			"Tool Deployment": {Repos: []string{"alaudadevops/helm*"}},
+		},
+	})
+	got := pm.PillarsForRepo("alaudadevops/helm-charts")
+	if !equalUnordered(got, []string{"CI/CD", "Tool Deployment"}) {
+		t.Fatalf("want [CI/CD, Tool Deployment], got %v", got)
+	}
+}
+
+func TestPillarMap_ComponentMatch(t *testing.T) {
+	pm := contributions.NewPillarMap(config.TeamAnalytics{
+		Pillars: map[string]config.PillarMapping{
+			"CI/CD":            {Components: []string{"Tekton"}},
+			"Tool Integration": {Components: []string{"Connectors"}},
+		},
+	})
+	got := pm.PillarsForComponents([]string{"tekton", "Connectors"})
+	if !equalUnordered(got, []string{"CI/CD", "Tool Integration"}) {
+		t.Fatalf("want both, got %v", got)
+	}
+	if got := pm.PillarsForComponents([]string{"unknown"}); len(got) != 0 {
+		t.Fatalf("want empty, got %v", got)
+	}
+}
+
+func TestPillarMap_Empty(t *testing.T) {
+	pm := contributions.NewPillarMap(config.TeamAnalytics{})
+	if pm == nil {
+		t.Fatal("want non-nil")
+	}
+	if pm.Configured() {
+		t.Fatal("want not configured")
+	}
+	if got := pm.PillarsForRepo("any/repo"); len(got) != 0 {
+		t.Fatalf("want empty, got %v", got)
+	}
+	if got := pm.PillarsForComponents([]string{"any"}); len(got) != 0 {
+		t.Fatalf("want empty, got %v", got)
+	}
+}
+
+func TestPillarMap_OrderIsStableAlpha(t *testing.T) {
+	pm := contributions.NewPillarMap(config.TeamAnalytics{
+		Pillars: map[string]config.PillarMapping{
+			"Z": {Repos: []string{"o/z"}},
+			"A": {Repos: []string{"o/a"}},
+			"M": {Repos: []string{"o/m"}},
+		},
+	})
+	got := pm.Order()
+	want := []string{"A", "M", "Z"}
+	if len(got) != len(want) {
+		t.Fatalf("len(order) = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func equalUnordered(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ac := append([]string(nil), a...)
+	bc := append([]string(nil), b...)
+	sort.Strings(ac)
+	sort.Strings(bc)
+	for i := range ac {
+		if ac[i] != bc[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/roadmap-planner/backend/internal/contributions/service.go
+++ b/roadmap-planner/backend/internal/contributions/service.go
@@ -80,6 +80,7 @@ type MemberSummary struct {
 type Bucket struct {
 	WeekStart time.Time `json:"week_start"`
 	JiraDone  int       `json:"jira_done"`
+	Points    float64   `json:"points"`
 	PRsMerged int       `json:"prs_merged"`
 	Reviews   int       `json:"reviews"`
 }
@@ -119,6 +120,7 @@ func (s *Service) TeamOverview(ctx context.Context, q storage.MemberWeekQuery) (
 			buckets[r.WeekStart] = bk
 		}
 		bk.JiraDone += r.JiraIssuesDone
+		bk.Points += r.JiraPointsDone
 		bk.PRsMerged += r.PRsMerged
 		bk.Reviews += r.PRsReviewed
 	}

--- a/roadmap-planner/backend/internal/contributions/service.go
+++ b/roadmap-planner/backend/internal/contributions/service.go
@@ -31,11 +31,30 @@ import (
 
 // Service is the read-only contributions API surface.
 type Service struct {
-	store storage.Store
+	store    storage.Store
+	pillarMP *PillarMap
 }
 
 func NewService(store storage.Store) *Service {
-	return &Service{store: store}
+	return &Service{store: store, pillarMP: &PillarMap{}}
+}
+
+// SetPillarMap installs the pillar attribution map. Called from main.go
+// after config load. Safe to call once at startup; not thread-safe to
+// swap at runtime.
+func (s *Service) SetPillarMap(pm *PillarMap) {
+	if pm == nil {
+		pm = &PillarMap{}
+	}
+	s.pillarMP = pm
+}
+
+// PillarMap returns the configured attribution map (never nil).
+func (s *Service) PillarMap() *PillarMap {
+	if s.pillarMP == nil {
+		return &PillarMap{}
+	}
+	return s.pillarMP
 }
 
 // MemberSummary is one row of the team-overview dashboard.

--- a/roadmap-planner/backend/internal/contributions/service.go
+++ b/roadmap-planner/backend/internal/contributions/service.go
@@ -21,6 +21,8 @@ package contributions
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
 	"sort"
 	"time"
 
@@ -37,6 +39,13 @@ func NewService(store storage.Store) *Service {
 }
 
 // MemberSummary is one row of the team-overview dashboard.
+//
+// Components is the *flat* set of Jira components seen on this member's
+// issue snapshots in the window. The frontend uses it to derive the
+// member's pillar by matching against BasicPillar.component (same logic
+// the roadmap tab uses), so the team-analytics view stays consistent
+// with the roadmap source-of-truth instead of relying on a free-form
+// operator-set members.pillar_id.
 type MemberSummary struct {
 	MemberID         string   `json:"member_id"`
 	WeekTotals       []Bucket `json:"week_totals"`
@@ -45,6 +54,7 @@ type MemberSummary struct {
 	PRsMerged        int      `json:"prs_merged"`
 	PRsReviewed      int      `json:"prs_reviewed"`
 	ReviewLatencyP50 float64  `json:"review_latency_p50_hours,omitempty"`
+	Components       []string `json:"components,omitempty"`
 }
 
 // Bucket is one weekly aggregation point.
@@ -94,6 +104,19 @@ func (s *Service) TeamOverview(ctx context.Context, q storage.MemberWeekQuery) (
 		bk.Reviews += r.PRsReviewed
 	}
 
+	// Components per member — one extra query, joined client-side onto
+	// each MemberSummary. The aggregator's rollup table doesn't carry
+	// component lists (only the {member, week, pillar, component} primary
+	// key with one row per component-tag), so this is the cheapest way
+	// to surface a per-member component list to the frontend without
+	// schema changes.
+	componentsByMember, err := s.componentsByMember(ctx, q)
+	if err != nil {
+		// Non-fatal: an empty components list just means the frontend
+		// falls back to the operator-set pillar. Log path: caller logs.
+		componentsByMember = map[string][]string{}
+	}
+
 	out := make([]MemberSummary, 0, len(byMember))
 	for id, ms := range byMember {
 		bks := make([]Bucket, 0, len(bucketByMember[id]))
@@ -102,9 +125,89 @@ func (s *Service) TeamOverview(ctx context.Context, q storage.MemberWeekQuery) (
 		}
 		sort.Slice(bks, func(i, j int) bool { return bks[i].WeekStart.Before(bks[j].WeekStart) })
 		ms.WeekTotals = bks
+		ms.Components = componentsByMember[id]
 		out = append(out, *ms)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].MemberID < out[j].MemberID })
+	return out, nil
+}
+
+// componentsByMember tallies the distinct components each member has
+// touched in the [From, To) window. Latest-snapshot-per-issue de-dup
+// (so one issue contributes once even across multiple collection cycles),
+// then a flat union of components across the member's deduped issue
+// set. Order is descending by frequency, then alphabetic — useful when
+// the frontend wants "primary component" without an extra count map.
+func (s *Service) componentsByMember(ctx context.Context, q storage.MemberWeekQuery) (map[string][]string, error) {
+	d, ok := s.store.(interface {
+		Dialect() storage.Dialect
+		DB() *sql.DB
+	})
+	if !ok {
+		return nil, nil
+	}
+	dialect := d.Dialect()
+	db := d.DB()
+
+	sqlStr := rebindSimple(dialect, `
+		SELECT assignee_id, components
+		FROM (
+		  SELECT s.assignee_id, s.components, s.issue_key,
+		         ROW_NUMBER() OVER (PARTITION BY s.issue_key ORDER BY r.captured_at DESC) AS rn
+		  FROM issue_snapshots s
+		  JOIN collection_runs r ON s.run_id = r.id
+		  WHERE s.assignee_id IS NOT NULL AND s.assignee_id <> ''
+		    AND s.created_at < ?
+		    AND (s.resolved_at IS NULL OR s.resolved_at >= ?)
+		) ranked
+		WHERE rn = 1`)
+	rows, err := db.QueryContext(ctx, sqlStr, q.To, q.From)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	tally := map[string]map[string]int{}
+	for rows.Next() {
+		var memberID string
+		var raw sql.NullString
+		if err := rows.Scan(&memberID, &raw); err != nil {
+			return nil, err
+		}
+		if !raw.Valid || raw.String == "" || raw.String == "null" {
+			continue
+		}
+		var comps []string
+		if err := json.Unmarshal([]byte(raw.String), &comps); err != nil {
+			continue
+		}
+		mp, ok := tally[memberID]
+		if !ok {
+			mp = map[string]int{}
+			tally[memberID] = mp
+		}
+		for _, c := range comps {
+			if c != "" {
+				mp[c]++
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	out := make(map[string][]string, len(tally))
+	for mid, counts := range tally {
+		list := make([]string, 0, len(counts))
+		for c := range counts {
+			list = append(list, c)
+		}
+		sort.Slice(list, func(i, j int) bool {
+			if counts[list[i]] != counts[list[j]] {
+				return counts[list[i]] > counts[list[j]]
+			}
+			return list[i] < list[j]
+		})
+		out[mid] = list
+	}
 	return out, nil
 }
 

--- a/roadmap-planner/backend/internal/contributions/service_extras.go
+++ b/roadmap-planner/backend/internal/contributions/service_extras.go
@@ -573,6 +573,9 @@ func round1(v float64) float64 { return float64(int(v*10+0.5)) / 10 }
 // returns `YYYY-MM-DD`; Postgres' `date_trunc('week', ...)` returns a
 // timestamp) back to time.Time. The driver doesn't infer a column type
 // for a synthesised SELECT expression, so we get strings, not times.
+// Layout-fallback list covers both SQLite (date-only) and Postgres
+// (timestamp / RFC3339) outputs without requiring dialect-specific
+// branching at the call site.
 func parseWeek(s string) (time.Time, error) {
 	for _, layout := range []string{
 		"2006-01-02",

--- a/roadmap-planner/backend/internal/contributions/service_extras.go
+++ b/roadmap-planner/backend/internal/contributions/service_extras.go
@@ -175,46 +175,123 @@ type PillarBucket struct {
 	JiraDone  int       `json:"jira_done"`
 }
 
-// PillarThroughput returns weekly PR-merged / Jira-done counts per
-// pillar, restricted to members with a non-empty `pillar_id`. Members
-// without a pillar are surfaced under the synthetic "Unassigned" key
-// so the dashboard can hint that pillars need to be set.
+// PillarThroughput returns weekly PR-merged / Jira-done counts per pillar.
+//
+// Attribution is per-PR (via repo→pillars in the configured PillarMap)
+// and per-issue (via Jira components → pillars). A PR or issue that maps
+// to multiple pillars contributes one full unit to each — there is no
+// proportional split. Member-level totals are unaffected; this rollup
+// is independent of `members.pillar_id`.
+//
+// Items that don't match any configured pillar fall under the synthetic
+// "Unassigned" key so the dashboard can prompt the operator to extend
+// the mapping.
 func (s *Service) PillarThroughput(ctx context.Context, q storage.MemberWeekQuery) ([]PillarBucket, error) {
-	rows, err := s.store.MemberWeekMetrics(ctx, q)
-	if err != nil {
-		return nil, err
+	d, ok := s.store.(interface {
+		Dialect() storage.Dialect
+		DB() *sql.DB
+	})
+	if !ok {
+		return nil, fmt.Errorf("pillars: store does not expose Dialect/DB")
 	}
-	members, err := s.store.ListMembers(ctx)
-	if err != nil {
-		return nil, err
-	}
-	pillarOf := map[string]string{}
-	for _, m := range members {
-		p := m.PillarID
-		if p == "" {
-			p = "Unassigned"
-		}
-		pillarOf[m.ID] = p
-	}
+	dialect := d.Dialect()
+	db := d.DB()
+	pm := s.PillarMap()
+
 	type key struct {
 		Pillar string
 		Week   time.Time
 	}
 	agg := map[key]*PillarBucket{}
-	for _, r := range rows {
-		p := pillarOf[r.MemberID]
-		if p == "" {
-			p = "Unassigned"
-		}
-		k := key{Pillar: p, Week: r.WeekStart}
+	bump := func(pillar string, week time.Time, prs, jira int) {
+		k := key{Pillar: pillar, Week: week}
 		b, ok := agg[k]
 		if !ok {
-			b = &PillarBucket{Pillar: p, WeekStart: r.WeekStart}
+			b = &PillarBucket{Pillar: pillar, WeekStart: week}
 			agg[k] = b
 		}
-		b.PRsMerged += r.PRsMerged
-		b.JiraDone += r.JiraIssuesDone
+		b.PRsMerged += prs
+		b.JiraDone += jira
 	}
+
+	// PRs by repo × week. We pull (repo_id, week, count) and fan out per
+	// repo to the pillars it claims.
+	prSQL := rebindSimple(dialect, fmt.Sprintf(`
+		SELECT pr.repo_id, %s AS week_start, COUNT(*) AS n
+		FROM pull_requests pr
+		WHERE pr.merged_at IS NOT NULL
+		  AND pr.merged_at >= ?
+		  AND pr.merged_at <  ?
+		GROUP BY pr.repo_id, %s`, dialect.WeekStart("pr.merged_at"), dialect.WeekStart("pr.merged_at")))
+	prRows, err := db.QueryContext(ctx, prSQL, q.From, q.To)
+	if err != nil {
+		return nil, fmt.Errorf("pillars: pr aggregate: %w", err)
+	}
+	defer prRows.Close()
+	for prRows.Next() {
+		var repo string
+		var week time.Time
+		var n int
+		if err := prRows.Scan(&repo, &week, &n); err != nil {
+			return nil, err
+		}
+		pillars := pm.PillarsForRepo(repo)
+		if len(pillars) == 0 {
+			bump("Unassigned", week, n, 0)
+			continue
+		}
+		for _, p := range pillars {
+			bump(p, week, n, 0)
+		}
+	}
+	if err := prRows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Jira issues done by week × components. Latest snapshot per issue,
+	// resolved_at in window, then expand the JSON components array and
+	// route to the matching pillars. Issues with no component or no
+	// configured mapping land under "Unassigned".
+	jiraSQL := rebindSimple(dialect, fmt.Sprintf(`
+		SELECT %s AS week_start, components
+		FROM (
+		  SELECT s.resolved_at, s.components, s.issue_key,
+		         ROW_NUMBER() OVER (PARTITION BY s.issue_key ORDER BY r.captured_at DESC) AS rn
+		  FROM issue_snapshots s
+		  JOIN collection_runs r ON s.run_id = r.id
+		  WHERE s.resolved_at IS NOT NULL
+		    AND s.resolved_at >= ?
+		    AND s.resolved_at <  ?
+		) ranked
+		WHERE rn = 1`, dialect.WeekStart("resolved_at")))
+	jRows, err := db.QueryContext(ctx, jiraSQL, q.From, q.To)
+	if err != nil {
+		return nil, fmt.Errorf("pillars: jira aggregate: %w", err)
+	}
+	defer jRows.Close()
+	for jRows.Next() {
+		var week time.Time
+		var rawComponents sql.NullString
+		if err := jRows.Scan(&week, &rawComponents); err != nil {
+			return nil, err
+		}
+		var comps []string
+		if rawComponents.Valid && rawComponents.String != "" && rawComponents.String != "null" {
+			_ = json.Unmarshal([]byte(rawComponents.String), &comps)
+		}
+		pillars := pm.PillarsForComponents(comps)
+		if len(pillars) == 0 {
+			bump("Unassigned", week, 0, 1)
+			continue
+		}
+		for _, p := range pillars {
+			bump(p, week, 0, 1)
+		}
+	}
+	if err := jRows.Err(); err != nil {
+		return nil, err
+	}
+
 	out := make([]PillarBucket, 0, len(agg))
 	for _, b := range agg {
 		out = append(out, *b)

--- a/roadmap-planner/backend/internal/contributions/service_extras.go
+++ b/roadmap-planner/backend/internal/contributions/service_extras.go
@@ -229,11 +229,14 @@ func (s *Service) PillarThroughput(ctx context.Context, q storage.MemberWeekQuer
 	}
 	defer prRows.Close()
 	for prRows.Next() {
-		var repo string
-		var week time.Time
+		var repo, weekRaw string
 		var n int
-		if err := prRows.Scan(&repo, &week, &n); err != nil {
+		if err := prRows.Scan(&repo, &weekRaw, &n); err != nil {
 			return nil, err
+		}
+		week, perr := parseWeek(weekRaw)
+		if perr != nil {
+			return nil, fmt.Errorf("pillars: parse pr week %q: %w", weekRaw, perr)
 		}
 		pillars := pm.PillarsForRepo(repo)
 		if len(pillars) == 0 {
@@ -270,10 +273,14 @@ func (s *Service) PillarThroughput(ctx context.Context, q storage.MemberWeekQuer
 	}
 	defer jRows.Close()
 	for jRows.Next() {
-		var week time.Time
+		var weekRaw string
 		var rawComponents sql.NullString
-		if err := jRows.Scan(&week, &rawComponents); err != nil {
+		if err := jRows.Scan(&weekRaw, &rawComponents); err != nil {
 			return nil, err
+		}
+		week, perr := parseWeek(weekRaw)
+		if perr != nil {
+			return nil, fmt.Errorf("pillars: parse jira week %q: %w", weekRaw, perr)
 		}
 		var comps []string
 		if rawComponents.Valid && rawComponents.String != "" && rawComponents.String != "null" {
@@ -561,3 +568,22 @@ func percentile(sorted []float64, p float64) float64 {
 }
 
 func round1(v float64) float64 { return float64(int(v*10+0.5)) / 10 }
+
+// parseWeek converts a `dialect.WeekStart(...)`-derived string (SQLite
+// returns `YYYY-MM-DD`; Postgres' `date_trunc('week', ...)` returns a
+// timestamp) back to time.Time. The driver doesn't infer a column type
+// for a synthesised SELECT expression, so we get strings, not times.
+func parseWeek(s string) (time.Time, error) {
+	for _, layout := range []string{
+		"2006-01-02",
+		"2006-01-02 15:04:05",
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02T15:04:05Z",
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unrecognised week format")
+}

--- a/roadmap-planner/backend/internal/contributions/service_extras.go
+++ b/roadmap-planner/backend/internal/contributions/service_extras.go
@@ -173,6 +173,7 @@ type PillarBucket struct {
 	WeekStart time.Time `json:"week_start"`
 	PRsMerged int       `json:"prs_merged"`
 	JiraDone  int       `json:"jira_done"`
+	Points    float64   `json:"points"`
 }
 
 // PillarThroughput returns weekly PR-merged / Jira-done counts per pillar.
@@ -203,7 +204,7 @@ func (s *Service) PillarThroughput(ctx context.Context, q storage.MemberWeekQuer
 		Week   time.Time
 	}
 	agg := map[key]*PillarBucket{}
-	bump := func(pillar string, week time.Time, prs, jira int) {
+	bump := func(pillar string, week time.Time, prs, jira int, pts float64) {
 		k := key{Pillar: pillar, Week: week}
 		b, ok := agg[k]
 		if !ok {
@@ -212,6 +213,7 @@ func (s *Service) PillarThroughput(ctx context.Context, q storage.MemberWeekQuer
 		}
 		b.PRsMerged += prs
 		b.JiraDone += jira
+		b.Points += pts
 	}
 
 	// PRs by repo × week. We pull (repo_id, week, count) and fan out per
@@ -240,11 +242,11 @@ func (s *Service) PillarThroughput(ctx context.Context, q storage.MemberWeekQuer
 		}
 		pillars := pm.PillarsForRepo(repo)
 		if len(pillars) == 0 {
-			bump("Unassigned", week, n, 0)
+			bump("Unassigned", week, n, 0, 0)
 			continue
 		}
 		for _, p := range pillars {
-			bump(p, week, n, 0)
+			bump(p, week, n, 0, 0)
 		}
 	}
 	if err := prRows.Err(); err != nil {
@@ -256,9 +258,9 @@ func (s *Service) PillarThroughput(ctx context.Context, q storage.MemberWeekQuer
 	// route to the matching pillars. Issues with no component or no
 	// configured mapping land under "Unassigned".
 	jiraSQL := rebindSimple(dialect, fmt.Sprintf(`
-		SELECT %s AS week_start, components
+		SELECT %s AS week_start, components, story_points
 		FROM (
-		  SELECT s.resolved_at, s.components, s.issue_key,
+		  SELECT s.resolved_at, s.components, s.story_points, s.issue_key,
 		         ROW_NUMBER() OVER (PARTITION BY s.issue_key ORDER BY r.captured_at DESC) AS rn
 		  FROM issue_snapshots s
 		  JOIN collection_runs r ON s.run_id = r.id
@@ -275,7 +277,8 @@ func (s *Service) PillarThroughput(ctx context.Context, q storage.MemberWeekQuer
 	for jRows.Next() {
 		var weekRaw string
 		var rawComponents sql.NullString
-		if err := jRows.Scan(&weekRaw, &rawComponents); err != nil {
+		var pts sql.NullFloat64
+		if err := jRows.Scan(&weekRaw, &rawComponents, &pts); err != nil {
 			return nil, err
 		}
 		week, perr := parseWeek(weekRaw)
@@ -286,13 +289,17 @@ func (s *Service) PillarThroughput(ctx context.Context, q storage.MemberWeekQuer
 		if rawComponents.Valid && rawComponents.String != "" && rawComponents.String != "null" {
 			_ = json.Unmarshal([]byte(rawComponents.String), &comps)
 		}
+		var points float64
+		if pts.Valid {
+			points = pts.Float64
+		}
 		pillars := pm.PillarsForComponents(comps)
 		if len(pillars) == 0 {
-			bump("Unassigned", week, 0, 1)
+			bump("Unassigned", week, 0, 1, points)
 			continue
 		}
 		for _, p := range pillars {
-			bump(p, week, 0, 1)
+			bump(p, week, 0, 1, points)
 		}
 	}
 	if err := jRows.Err(); err != nil {

--- a/roadmap-planner/backend/internal/contributions/service_extras.go
+++ b/roadmap-planner/backend/internal/contributions/service_extras.go
@@ -1,0 +1,486 @@
+/*
+Copyright 2024 The AlaudaDevops Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+// Service extras — supplementary aggregations for the new Team Analytics
+// views (pillar throughput, review network density, member-profile
+// extras). Kept in their own file so service.go stays focused on the
+// canonical TeamOverview / MemberDetail rollup reads.
+//
+// The queries here go straight to the raw tables (issue_snapshots,
+// pull_requests, pr_reviews, members) rather than through the rollup,
+// because the questions they answer aren't pre-aggregated:
+//
+//   - PillarThroughput needs members.pillar joined onto pull_requests.
+//   - NetworkDensity needs PR-level latency / orphan distribution and
+//     a cross-pillar review classification.
+//   - MemberProfile (components_touched, current sprint) reads
+//     issue_snapshots directly; the rollup throws away component
+//     information.
+
+package contributions
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/AlaudaDevops/toolbox/roadmap-planner/backend/internal/storage"
+)
+
+// ----------------------------------------------------------------------
+// /api/contributions/network — Review-network density panel
+// ----------------------------------------------------------------------
+
+// NetworkDensity is the aggregate review health summary used by the
+// Team Overview "Review network density" panel.
+//
+// All percentages are 0–100 (already multiplied), all latencies are in
+// hours. Counts are absolute. Empty (zero-value) is a valid response —
+// the dashboard renders "—" for unset values rather than spinning.
+type NetworkDensity struct {
+	From                       time.Time `json:"from"`
+	To                         time.Time `json:"to"`
+	PRsConsidered              int       `json:"prs_considered"`
+	PRsMerged                  int       `json:"prs_merged"`
+	OrphanPct                  float64   `json:"orphan_pct"`
+	FirstReviewUnder24hPct     float64   `json:"first_review_under_24h_pct"`
+	FirstReviewLatencyP50Hours float64   `json:"first_review_p50_hours"`
+	FirstReviewLatencyP90Hours float64   `json:"first_review_p90_hours"`
+	CrossPillarReviewPct       float64   `json:"cross_pillar_review_pct"`
+}
+
+// NetworkDensity returns the review-density rollup for the [From, To)
+// window of q. Filters on q.MemberIDs / q.PillarIDs are honoured if
+// set (a pillar slice asks "what does the network look like for this
+// pillar's authors").
+func (s *Service) NetworkDensity(ctx context.Context, q storage.MemberWeekQuery) (*NetworkDensity, error) {
+	d, ok := s.store.(interface {
+		Dialect() storage.Dialect
+		DB() *sql.DB
+	})
+	if !ok {
+		return nil, fmt.Errorf("network: store does not expose Dialect/DB")
+	}
+	dialect := d.Dialect()
+	db := d.DB()
+	out := &NetworkDensity{From: q.From, To: q.To}
+
+	// 1. PR-level distribution: latency to first review + orphan count.
+	//
+	// We bound by created_at (i.e., "PRs opened in the window") not
+	// merged_at — orphan rate measures *received review during life*,
+	// which is anchored on creation. Drafts are excluded because they
+	// shouldn't count toward orphan rate; we approximate by skipping
+	// PRs that closed without a merge AND without a review.
+	hours := hoursBetween(dialect, "first_review_at", "created_at")
+	prSQL := rebindSimple(dialect, fmt.Sprintf(`
+		SELECT
+		  COUNT(*) AS total,
+		  SUM(CASE WHEN merged_at IS NOT NULL THEN 1 ELSE 0 END) AS merged,
+		  SUM(CASE WHEN first_review_at IS NULL THEN 1 ELSE 0 END) AS orphans,
+		  SUM(CASE WHEN first_review_at IS NOT NULL AND %s <= 24.0
+		           THEN 1 ELSE 0 END) AS under24h
+		FROM pull_requests
+		WHERE created_at >= ? AND created_at < ?`, hours))
+
+	var total, merged, orphans, under24h sql.NullInt64
+	if err := db.QueryRowContext(ctx, prSQL, q.From, q.To).Scan(&total, &merged, &orphans, &under24h); err != nil {
+		return nil, fmt.Errorf("network pr-distribution: %w", err)
+	}
+	out.PRsConsidered = int(total.Int64)
+	out.PRsMerged = int(merged.Int64)
+	if total.Int64 > 0 {
+		out.OrphanPct = float64(orphans.Int64) / float64(total.Int64) * 100
+		out.FirstReviewUnder24hPct = float64(under24h.Int64) / float64(total.Int64) * 100
+	}
+
+	// 2. Latency p50 / p90.
+	//
+	// Pull every (latency_hours) value into Go and sort — the dataset
+	// is at most a few thousand rows in our deployments and this keeps
+	// the query portable (Postgres has percentile_cont, SQLite does
+	// not, and we want one query for both).
+	latSQL := rebindSimple(dialect, fmt.Sprintf(`
+		SELECT %s
+		FROM pull_requests
+		WHERE created_at >= ? AND created_at < ?
+		  AND first_review_at IS NOT NULL`, hours))
+	rows, err := db.QueryContext(ctx, latSQL, q.From, q.To)
+	if err != nil {
+		return nil, fmt.Errorf("network latencies: %w", err)
+	}
+	defer rows.Close()
+	var lats []float64
+	for rows.Next() {
+		var v sql.NullFloat64
+		if err := rows.Scan(&v); err != nil {
+			return nil, err
+		}
+		if v.Valid && v.Float64 >= 0 {
+			lats = append(lats, v.Float64)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(lats) > 0 {
+		sort.Float64s(lats)
+		out.FirstReviewLatencyP50Hours = round1(percentile(lats, 0.50))
+		out.FirstReviewLatencyP90Hours = round1(percentile(lats, 0.90))
+	}
+
+	// 3. Cross-pillar review %.
+	//
+	// A review is "cross-pillar" when the reviewer's pillar differs
+	// from the author's pillar AND both pillars are populated. Reviews
+	// where either side has no pillar are excluded from the
+	// denominator — we cannot answer the question without the data.
+	xSQL := rebindSimple(dialect, `
+		SELECT
+		  COUNT(*) AS total,
+		  SUM(CASE WHEN ma.pillar_id <> mr.pillar_id THEN 1 ELSE 0 END) AS xpillar
+		FROM pr_reviews rv
+		JOIN pull_requests pr ON pr.id = rv.pr_id
+		JOIN members ma ON ma.id = COALESCE(NULLIF(pr.author_id, ''), '')
+		JOIN members mr ON mr.id = COALESCE(NULLIF(rv.reviewer_id, ''), '')
+		WHERE rv.submitted_at >= ? AND rv.submitted_at < ?
+		  AND ma.pillar_id IS NOT NULL AND ma.pillar_id <> ''
+		  AND mr.pillar_id IS NOT NULL AND mr.pillar_id <> ''`)
+	var xTotal, xCross sql.NullInt64
+	if err := db.QueryRowContext(ctx, xSQL, q.From, q.To).Scan(&xTotal, &xCross); err != nil {
+		return nil, fmt.Errorf("network cross-pillar: %w", err)
+	}
+	if xTotal.Int64 > 0 {
+		out.CrossPillarReviewPct = float64(xCross.Int64) / float64(xTotal.Int64) * 100
+	}
+	return out, nil
+}
+
+// ----------------------------------------------------------------------
+// /api/contributions/pillars — Pillar throughput stack chart
+// ----------------------------------------------------------------------
+
+// PillarBucket is one (pillar, week) cell in the stack chart.
+type PillarBucket struct {
+	Pillar    string    `json:"pillar"`
+	WeekStart time.Time `json:"week_start"`
+	PRsMerged int       `json:"prs_merged"`
+	JiraDone  int       `json:"jira_done"`
+}
+
+// PillarThroughput returns weekly PR-merged / Jira-done counts per
+// pillar, restricted to members with a non-empty `pillar_id`. Members
+// without a pillar are surfaced under the synthetic "Unassigned" key
+// so the dashboard can hint that pillars need to be set.
+func (s *Service) PillarThroughput(ctx context.Context, q storage.MemberWeekQuery) ([]PillarBucket, error) {
+	rows, err := s.store.MemberWeekMetrics(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	members, err := s.store.ListMembers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	pillarOf := map[string]string{}
+	for _, m := range members {
+		p := m.PillarID
+		if p == "" {
+			p = "Unassigned"
+		}
+		pillarOf[m.ID] = p
+	}
+	type key struct {
+		Pillar string
+		Week   time.Time
+	}
+	agg := map[key]*PillarBucket{}
+	for _, r := range rows {
+		p := pillarOf[r.MemberID]
+		if p == "" {
+			p = "Unassigned"
+		}
+		k := key{Pillar: p, Week: r.WeekStart}
+		b, ok := agg[k]
+		if !ok {
+			b = &PillarBucket{Pillar: p, WeekStart: r.WeekStart}
+			agg[k] = b
+		}
+		b.PRsMerged += r.PRsMerged
+		b.JiraDone += r.JiraIssuesDone
+	}
+	out := make([]PillarBucket, 0, len(agg))
+	for _, b := range agg {
+		out = append(out, *b)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].WeekStart.Equal(out[j].WeekStart) {
+			return out[i].WeekStart.Before(out[j].WeekStart)
+		}
+		return out[i].Pillar < out[j].Pillar
+	})
+	return out, nil
+}
+
+// ----------------------------------------------------------------------
+// MemberDetail extras — components touched + current sprint
+// ----------------------------------------------------------------------
+
+// ComponentBucket is one row of the "components touched" bar chart on
+// the member profile.
+type ComponentBucket struct {
+	Component string `json:"component"`
+	Issues    int    `json:"issues"`
+}
+
+// SprintStats is the "this sprint" KPI cluster on the member profile.
+//
+// We use the *most recently mentioned* sprint id across the member's
+// open or recently-resolved issues as "the current sprint". This is a
+// pragmatic heuristic — there is no canonical "current sprint" in
+// Jira's data model that we can read without an extra API. The name
+// is whatever the latest snapshot recorded.
+type SprintStats struct {
+	Name      string `json:"name,omitempty"`
+	WIP       int    `json:"wip"`
+	Done      int    `json:"done"`
+	PRsOpen   int    `json:"prs_open"`
+	PRsMerged int    `json:"prs_merged"`
+}
+
+// MemberExtras packages everything the profile page wants beyond the
+// rollup numbers already returned by MemberDetail.
+type MemberExtras struct {
+	ComponentsTouched []ComponentBucket `json:"components_touched"`
+	Sprint            *SprintStats      `json:"sprint,omitempty"`
+}
+
+// MemberExtras computes the components-touched bars and current-sprint
+// stats for one member, scoped to the [From, To) window. Returns an
+// empty (non-nil) ComponentsTouched on no-data; Sprint is nil if the
+// member has no sprint association.
+func (s *Service) MemberExtras(ctx context.Context, memberID string, q storage.MemberWeekQuery) (*MemberExtras, error) {
+	d, ok := s.store.(interface {
+		Dialect() storage.Dialect
+		DB() *sql.DB
+	})
+	if !ok {
+		return nil, fmt.Errorf("member-extras: store does not expose Dialect/DB")
+	}
+	dialect := d.Dialect()
+	db := d.DB()
+	out := &MemberExtras{ComponentsTouched: []ComponentBucket{}}
+
+	// Components touched — pull every snapshot row for this member in
+	// the window, decode the JSON components array, and tally. We use
+	// only the latest snapshot per issue (ROW_NUMBER() over captured_at)
+	// so an issue isn't counted N times across collection cycles.
+	compSQL := rebindSimple(dialect, `
+		SELECT components
+		FROM (
+		  SELECT s.components,
+		         ROW_NUMBER() OVER (PARTITION BY s.issue_key ORDER BY r.captured_at DESC) AS rn
+		  FROM issue_snapshots s
+		  JOIN collection_runs r ON s.run_id = r.id
+		  WHERE s.assignee_id = ?
+		    AND s.created_at < ?
+		    AND (s.resolved_at IS NULL OR s.resolved_at >= ?)
+		) ranked
+		WHERE rn = 1`)
+	rows, err := db.QueryContext(ctx, compSQL, memberID, q.To, q.From)
+	if err != nil {
+		return nil, fmt.Errorf("components: %w", err)
+	}
+	defer rows.Close()
+	tally := map[string]int{}
+	for rows.Next() {
+		var raw sql.NullString
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		if !raw.Valid || raw.String == "" || raw.String == "null" {
+			continue
+		}
+		var comps []string
+		if err := json.Unmarshal([]byte(raw.String), &comps); err != nil {
+			continue // malformed; skip
+		}
+		for _, c := range comps {
+			if c != "" {
+				tally[c]++
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for c, n := range tally {
+		out.ComponentsTouched = append(out.ComponentsTouched, ComponentBucket{Component: c, Issues: n})
+	}
+	sort.Slice(out.ComponentsTouched, func(i, j int) bool {
+		if out.ComponentsTouched[i].Issues != out.ComponentsTouched[j].Issues {
+			return out.ComponentsTouched[i].Issues > out.ComponentsTouched[j].Issues
+		}
+		return out.ComponentsTouched[i].Component < out.ComponentsTouched[j].Component
+	})
+	if len(out.ComponentsTouched) > 8 {
+		out.ComponentsTouched = out.ComponentsTouched[:8]
+	}
+
+	// Current sprint — pick the most-recently-captured snapshot row
+	// with a non-empty sprint_id for this member. That gives us the
+	// sprint id + name; we then count WIP / Done by joining all rows
+	// with the same sprint id.
+	sprintSQL := rebindSimple(dialect, `
+		SELECT s.sprint_id, MAX(r.captured_at)
+		FROM issue_snapshots s
+		JOIN collection_runs r ON s.run_id = r.id
+		WHERE s.assignee_id = ? AND s.sprint_id IS NOT NULL AND s.sprint_id <> ''
+		GROUP BY s.sprint_id
+		ORDER BY MAX(r.captured_at) DESC
+		LIMIT 1`)
+	var sprintID sql.NullString
+	var lastSeen sql.NullTime
+	err = db.QueryRowContext(ctx, sprintSQL, memberID).Scan(&sprintID, &lastSeen)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("sprint pick: %w", err)
+	}
+	if sprintID.Valid && sprintID.String != "" {
+		stats, err := s.sprintCounts(ctx, db, dialect, memberID, sprintID.String)
+		if err != nil {
+			return nil, err
+		}
+		out.Sprint = stats
+	}
+	return out, nil
+}
+
+// sprintCounts gathers (wip, done, prs_open, prs_merged) for a member
+// scoped to one sprint. WIP / Done come from the *latest* snapshot
+// per issue under that sprint id; PR counts come from pull_requests
+// linked via epic_key (best-effort).
+func (s *Service) sprintCounts(ctx context.Context, db *sql.DB, dialect storage.Dialect, memberID, sprintID string) (*SprintStats, error) {
+	out := &SprintStats{Name: sprintID} // default name = id; we overwrite below if we see something better
+
+	q := rebindSimple(dialect, `
+		SELECT s.status, s.resolved_at
+		FROM (
+		  SELECT s.status, s.resolved_at, s.issue_key, s.sprint_id, s.assignee_id,
+		         ROW_NUMBER() OVER (PARTITION BY s.issue_key ORDER BY r.captured_at DESC) AS rn
+		  FROM issue_snapshots s
+		  JOIN collection_runs r ON s.run_id = r.id
+		  WHERE s.sprint_id = ? AND s.assignee_id = ?
+		) s
+		WHERE s.rn = 1`)
+	rows, err := db.QueryContext(ctx, q, sprintID, memberID)
+	if err != nil {
+		return nil, fmt.Errorf("sprint counts: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var status string
+		var resolved sql.NullTime
+		if err := rows.Scan(&status, &resolved); err != nil {
+			return nil, err
+		}
+		if resolved.Valid {
+			out.Done++
+		} else {
+			out.WIP++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// PR counts: look at pull_requests opened by this member that
+	// reference any issue assigned to the sprint via epic_key. This
+	// only works for projects where the linker resolves an epic key
+	// onto every PR — when it doesn't, the counts stay at zero.
+	prQ := rebindSimple(dialect, `
+		SELECT
+		  SUM(CASE WHEN merged_at IS NOT NULL THEN 1 ELSE 0 END),
+		  SUM(CASE WHEN merged_at IS NULL AND closed_at IS NULL THEN 1 ELSE 0 END)
+		FROM pull_requests
+		WHERE author_id = ?
+		  AND epic_key IN (
+		    SELECT DISTINCT issue_key FROM issue_snapshots
+		    WHERE sprint_id = ? AND assignee_id = ?
+		  )`)
+	var merged, open sql.NullInt64
+	if err := db.QueryRowContext(ctx, prQ, memberID, sprintID, memberID).Scan(&merged, &open); err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("sprint pr counts: %w", err)
+	}
+	out.PRsMerged = int(merged.Int64)
+	out.PRsOpen = int(open.Int64)
+	return out, nil
+}
+
+// ----------------------------------------------------------------------
+// helpers
+// ----------------------------------------------------------------------
+
+// rebindSimple is a duplicate of storage.rebind — kept here to avoid
+// exporting the unexported helper from storage. The aggregator does
+// the same trick.
+func rebindSimple(d storage.Dialect, q string) string {
+	if d.Placeholder(1) == "?" {
+		return q
+	}
+	var b []byte
+	n := 1
+	for i := 0; i < len(q); i++ {
+		if q[i] == '?' {
+			b = append(b, []byte(d.Placeholder(n))...)
+			n++
+		} else {
+			b = append(b, q[i])
+		}
+	}
+	return string(b)
+}
+
+// hoursBetween returns a SQL expression evaluating to the number of
+// hours between `endCol` and `startCol` (decimal). Dialect-aware:
+//
+//   - SQLite: julianday(end) - julianday(start) yields fractional days;
+//     multiply by 24.
+//   - Postgres: extract(epoch from end - start) yields seconds; divide
+//     by 3600.
+//
+// Both cols may be expressions or column names; the caller is on the
+// hook for safe quoting if interpolating untrusted strings (we don't —
+// only fixed column names go through here).
+func hoursBetween(d storage.Dialect, endCol, startCol string) string {
+	if d.Name() == "postgres" {
+		return fmt.Sprintf("EXTRACT(EPOCH FROM (%s - %s)) / 3600.0", endCol, startCol)
+	}
+	return fmt.Sprintf("(julianday(%s) - julianday(%s)) * 24.0", endCol, startCol)
+}
+
+// percentile returns the p-th percentile (0..1) of a sorted ascending
+// slice using nearest-rank rounded down. Returns 0 for empty input.
+func percentile(sorted []float64, p float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 1 {
+		return sorted[len(sorted)-1]
+	}
+	idx := int(p * float64(len(sorted)))
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+func round1(v float64) float64 { return float64(int(v*10+0.5)) / 10 }

--- a/roadmap-planner/backend/internal/github/sync.go
+++ b/roadmap-planner/backend/internal/github/sync.go
@@ -64,6 +64,12 @@ func (d *defaultLinker) Link(pr PullRequest) string {
 // in the last BackfillDays days. Subsequent runs resume from one hour
 // before the previous run's CapturedAt (the overlap absorbs any clock
 // skew or PRs that mutated state without bumping `updated_at`).
+//
+// Wildcard expansion: a RepoConfig with Name == "*" (e.g. "AlaudaDevops/*")
+// is resolved at Sync time against /orgs/{owner}/repos. By default
+// archived repos and forks are filtered out and the resolved list is
+// cached for WildcardTTL (24 h by default). Toggle the filters and TTL
+// on this struct after construction if needed.
 type Syncer struct {
 	client       *Client
 	store        storage.Store
@@ -71,6 +77,15 @@ type Syncer struct {
 	linker       Linker
 	logger       *zap.Logger
 	backfillDays int
+
+	// Wildcard expansion knobs. All have sensible defaults; flip them
+	// from the caller (e.g. cmd/server) before Sync is invoked.
+	WildcardTTL     time.Duration // 0 -> DefaultWildcardTTL (24 h)
+	IncludeArchived bool          // default false (archived repos skipped)
+	IncludeForks    bool          // default false (forks skipped)
+
+	wildcardCache *wildcardCache
+	nowFn         func() time.Time // injectable for cache-TTL tests
 }
 
 // RepoConfig describes one repo to track. Pillar/Component are optional
@@ -93,12 +108,15 @@ func NewSyncer(client *Client, store storage.Store, repos []RepoConfig, linker L
 		backfillDays = 180
 	}
 	return &Syncer{
-		client:       client,
-		store:        store,
-		repos:        repos,
-		linker:       linker,
-		logger:       logger.WithComponent("github-syncer"),
-		backfillDays: backfillDays,
+		client:        client,
+		store:         store,
+		repos:         repos,
+		linker:        linker,
+		logger:        logger.WithComponent("github-syncer"),
+		backfillDays:  backfillDays,
+		WildcardTTL:   DefaultWildcardTTL,
+		wildcardCache: newWildcardCache(),
+		nowFn:         time.Now,
 	}
 }
 
@@ -113,6 +131,21 @@ func (s *Syncer) Sync(ctx context.Context) error {
 		return nil
 	}
 
+	// Resolve OWNER/* specs against the org-repos endpoint before we
+	// start the per-repo loop. A wildcard-expansion failure is recorded
+	// but does not abort the cycle: any explicit + already-resolved
+	// repos are still synced.
+	resolved, resolveErr := s.resolveRepos(ctx)
+	if resolveErr != nil {
+		s.logger.Warn("wildcard repo resolution failed (partial)", zap.Error(resolveErr))
+	}
+	if len(resolved) == 0 {
+		if resolveErr != nil {
+			return resolveErr
+		}
+		return nil
+	}
+
 	// First run: reach back BackfillDays. Subsequent runs: resume from
 	// one hour before the previous CapturedAt to absorb clock skew.
 	since := time.Now().AddDate(0, 0, -s.backfillDays)
@@ -124,14 +157,15 @@ func (s *Syncer) Sync(ctx context.Context) error {
 	s.logger.Info("github sync starting",
 		zap.String("mode", mode),
 		zap.Time("since", since),
-		zap.Int("repos", len(s.repos)))
+		zap.Int("specs", len(s.repos)),
+		zap.Int("repos", len(resolved)))
 
 	runStart := time.Now()
 	runID := fmt.Sprintf("gh-%d", runStart.UnixNano())
 	totalPRs, totalReviews := 0, 0
-	var firstErr error
+	firstErr := resolveErr
 
-	for _, repo := range s.repos {
+	for _, repo := range resolved {
 		prs, err := s.client.ListPullRequests(ctx, repo.Owner, repo.Name, ListPullRequestsOptions{
 			State: "all", Sort: "updated", Direction: "desc",
 			Since: since, MaxPages: 10,

--- a/roadmap-planner/backend/internal/github/sync_wildcard_test.go
+++ b/roadmap-planner/backend/internal/github/sync_wildcard_test.go
@@ -1,0 +1,248 @@
+/*
+Copyright 2024 The AlaudaDevops Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// pageOneRepos / pageTwoRepos mock two pages of /orgs/AlaudaDevops/repos.
+// Names chosen so a sorted assertion pins down exactly which repos
+// survive the archived/fork filter.
+var pageOneRepos = []orgRepo{
+	{Name: "alpha", Archived: false, Fork: false}, // keep
+	{Name: "beta-archived", Archived: true, Fork: false}, // drop (archived)
+	{Name: "gamma-fork", Archived: false, Fork: true},    // drop (fork)
+}
+var pageTwoRepos = []orgRepo{
+	{Name: "delta", Archived: false, Fork: false}, // keep
+	{Name: "epsilon-both", Archived: true, Fork: true}, // drop (both flags)
+}
+
+// newOrgReposServer returns an httptest server that serves two pages of
+// /orgs/{org}/repos and counts the number of API hits via *hits.
+func newOrgReposServer(t *testing.T, hits *int32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(hits, 1)
+		if !strings.HasPrefix(r.URL.Path, "/orgs/") || !strings.HasSuffix(r.URL.Path, "/repos") {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		page := r.URL.Query().Get("page")
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-RateLimit-Remaining", "5000")
+
+		var body []orgRepo
+		switch page {
+		case "1", "":
+			// Pad to 100 entries so the client knows another page might exist.
+			body = padTo100(pageOneRepos)
+		case "2":
+			body = pageTwoRepos
+		default:
+			body = []orgRepo{}
+		}
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+}
+
+// padTo100 returns a copy of in extended to 100 elements with synthetic
+// "filler-N" repos that all get filtered out (we mark them archived).
+// The wildcard expansion only stops paging once a short page comes back,
+// so the first page must be full-length to force a second request.
+func padTo100(in []orgRepo) []orgRepo {
+	out := make([]orgRepo, 0, 100)
+	out = append(out, in...)
+	for i := len(out); i < 100; i++ {
+		out = append(out, orgRepo{Name: "filler", Archived: true})
+	}
+	return out
+}
+
+// TestResolveRepos_WildcardFiltersArchivedAndForks walks the two-page
+// fixture and asserts the resolver returns only active, non-fork repos
+// in the expected order.
+func TestResolveRepos_WildcardFiltersArchivedAndForks(t *testing.T) {
+	var hits int32
+	srv := newOrgReposServer(t, &hits)
+	t.Cleanup(srv.Close)
+
+	c := New(srv.URL, "tok", srv.Client())
+	s := &Syncer{
+		client:        c,
+		repos:         []RepoConfig{{Owner: "AlaudaDevops", Name: "*"}},
+		WildcardTTL:   time.Hour,
+		wildcardCache: newWildcardCache(),
+		nowFn:         time.Now,
+	}
+
+	got, err := s.resolveRepos(context.Background())
+	if err != nil {
+		t.Fatalf("resolveRepos: %v", err)
+	}
+	names := repoNames(got)
+	sort.Strings(names)
+	want := []string{"AlaudaDevops/alpha", "AlaudaDevops/delta"}
+	if !equalStringSlices(names, want) {
+		t.Fatalf("resolved repos = %v, want %v", names, want)
+	}
+	if got := atomic.LoadInt32(&hits); got != 2 {
+		t.Fatalf("api hits = %d, want 2 (two pages)", got)
+	}
+}
+
+// TestResolveRepos_WildcardCachedWithinTTL asserts the second resolve
+// inside the TTL window does not hit the API, and a third resolve
+// after the TTL expires triggers a refresh.
+func TestResolveRepos_WildcardCachedWithinTTL(t *testing.T) {
+	var hits int32
+	srv := newOrgReposServer(t, &hits)
+	t.Cleanup(srv.Close)
+
+	c := New(srv.URL, "tok", srv.Client())
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	s := &Syncer{
+		client:        c,
+		repos:         []RepoConfig{{Owner: "AlaudaDevops", Name: "*"}},
+		WildcardTTL:   time.Hour,
+		wildcardCache: newWildcardCache(),
+		nowFn:         func() time.Time { return now },
+	}
+
+	if _, err := s.resolveRepos(context.Background()); err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+	firstHits := atomic.LoadInt32(&hits)
+
+	// Second resolve inside the TTL window -> cache hit, no new requests.
+	if _, err := s.resolveRepos(context.Background()); err != nil {
+		t.Fatalf("second resolve: %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got != firstHits {
+		t.Fatalf("after TTL-cached resolve: hits=%d, want %d (no new API calls)", got, firstHits)
+	}
+
+	// Advance the clock past the TTL -> next resolve should refresh.
+	now = now.Add(2 * time.Hour)
+	if _, err := s.resolveRepos(context.Background()); err != nil {
+		t.Fatalf("third resolve: %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got <= firstHits {
+		t.Fatalf("after TTL-expiry resolve: hits=%d, want > %d (cache refresh)", got, firstHits)
+	}
+}
+
+// TestResolveRepos_ExplicitEntryWinsAlongsideWildcard asserts that when
+// an operator writes both `OWNER/*` and `OWNER/foo:my-component`, the
+// explicit entry retains its component label even though `OWNER/*`
+// would also include `foo`.
+func TestResolveRepos_ExplicitEntryWinsAlongsideWildcard(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-RateLimit-Remaining", "5000")
+		page := r.URL.Query().Get("page")
+		if page == "1" || page == "" {
+			_ = json.NewEncoder(w).Encode([]orgRepo{
+				{Name: "alpha"}, {Name: "beta"},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]orgRepo{})
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(srv.URL, "tok", srv.Client())
+	s := &Syncer{
+		client: c,
+		repos: []RepoConfig{
+			{Owner: "AlaudaDevops", Name: "alpha", Component: "my-component"},
+			{Owner: "AlaudaDevops", Name: "*"},
+		},
+		WildcardTTL:   time.Hour,
+		wildcardCache: newWildcardCache(),
+		nowFn:         time.Now,
+	}
+
+	got, err := s.resolveRepos(context.Background())
+	if err != nil {
+		t.Fatalf("resolveRepos: %v", err)
+	}
+
+	// We expect 3 entries: explicit alpha (with label) + wildcard alpha
+	// (no label) + wildcard beta (no label). Explicit entries are not
+	// deduplicated against wildcard expansions.
+	var explicitHit, wildcardHit bool
+	for _, r := range got {
+		if r.Owner == "AlaudaDevops" && r.Name == "alpha" {
+			if r.Component == "my-component" {
+				explicitHit = true
+			} else {
+				wildcardHit = true
+			}
+		}
+	}
+	if !explicitHit {
+		t.Fatal("explicit AlaudaDevops/alpha:my-component was lost in resolution")
+	}
+	if !wildcardHit {
+		t.Fatal("wildcard AlaudaDevops/alpha (no component) was lost in resolution")
+	}
+	if len(got) != 3 {
+		t.Fatalf("resolved %d repos, want 3 (explicit alpha + wildcard alpha + wildcard beta); got=%v",
+			len(got), repoNames(got))
+	}
+}
+
+// TestParseWildcardOwner pins down the helper used by main.go's
+// parseRepos to detect wildcard specs.
+func TestParseWildcardOwner(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"AlaudaDevops/*", "AlaudaDevops"},
+		{"AlaudaDevops/toolbox", ""},
+		{"AlaudaDevops/", ""},
+		{"/*", ""},
+		{"AlaudaDevops/*/sub", ""},
+	}
+	for _, c := range cases {
+		if got := parseWildcardOwner(c.in); got != c.want {
+			t.Errorf("parseWildcardOwner(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func repoNames(repos []RepoConfig) []string {
+	out := make([]string, 0, len(repos))
+	for _, r := range repos {
+		out = append(out, r.FullName())
+	}
+	return out
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/roadmap-planner/backend/internal/github/sync_wildcard_test.go
+++ b/roadmap-planner/backend/internal/github/sync_wildcard_test.go
@@ -23,12 +23,12 @@ import (
 // Names chosen so a sorted assertion pins down exactly which repos
 // survive the archived/fork filter.
 var pageOneRepos = []orgRepo{
-	{Name: "alpha", Archived: false, Fork: false}, // keep
+	{Name: "alpha", Archived: false, Fork: false},        // keep
 	{Name: "beta-archived", Archived: true, Fork: false}, // drop (archived)
 	{Name: "gamma-fork", Archived: false, Fork: true},    // drop (fork)
 }
 var pageTwoRepos = []orgRepo{
-	{Name: "delta", Archived: false, Fork: false}, // keep
+	{Name: "delta", Archived: false, Fork: false},      // keep
 	{Name: "epsilon-both", Archived: true, Fork: true}, // drop (both flags)
 }
 

--- a/roadmap-planner/backend/internal/github/wildcard.go
+++ b/roadmap-planner/backend/internal/github/wildcard.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2024 The AlaudaDevops Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultWildcardTTL is how long a resolved OWNER/* expansion stays
+// cached before the next Syncer cycle re-fetches it. Operators rarely
+// add or archive repos within a 24 h window, so a daily refresh keeps
+// the API budget tiny while still picking up new repos in bounded time.
+const DefaultWildcardTTL = 24 * time.Hour
+
+// orgRepo is the slim subset of the /orgs/{org}/repos response we use
+// to filter wildcard results. Field tags mirror GitHub's JSON.
+type orgRepo struct {
+	Name     string `json:"name"`
+	Archived bool   `json:"archived"`
+	Fork     bool   `json:"fork"`
+}
+
+// listOrgRepos pages through GET /orgs/{org}/repos and returns every
+// non-archived, non-fork repo. Both filters are togglable from the
+// caller — the Syncer threads its IncludeArchived / IncludeForks flags
+// through here.
+//
+// We follow the GitHub convention of `per_page=100` and walk pages by
+// number until a short page is returned. The Client's `do` helper is
+// already paginating-friendly (see client.go ListPullRequests).
+func (c *Client) listOrgRepos(ctx context.Context, org string, includeArchived, includeForks bool) ([]orgRepo, error) {
+	out := make([]orgRepo, 0, 64)
+	const perPage = 100
+	for page := 1; ; page++ {
+		q := url.Values{}
+		q.Set("per_page", strconv.Itoa(perPage))
+		q.Set("type", "all")
+		q.Set("page", strconv.Itoa(page))
+
+		path := fmt.Sprintf("/orgs/%s/repos?%s", url.PathEscape(org), q.Encode())
+		var batch []orgRepo
+		if err := c.do(ctx, "GET", path, nil, &batch); err != nil {
+			return nil, fmt.Errorf("list org repos %s page %d: %w", org, page, err)
+		}
+		for _, r := range batch {
+			if !includeArchived && r.Archived {
+				continue
+			}
+			if !includeForks && r.Fork {
+				continue
+			}
+			out = append(out, r)
+		}
+		if len(batch) < perPage {
+			break
+		}
+	}
+	return out, nil
+}
+
+// wildcardCacheEntry holds a resolved expansion plus its mint time.
+type wildcardCacheEntry struct {
+	repos    []RepoConfig
+	resolved time.Time
+}
+
+// wildcardCache is a tiny per-Syncer cache, keyed by owner. We don't
+// share across Syncer instances — there's at most one process-wide
+// Syncer in production, and tests want fresh state per case.
+type wildcardCache struct {
+	mu      sync.Mutex
+	entries map[string]wildcardCacheEntry
+}
+
+func newWildcardCache() *wildcardCache {
+	return &wildcardCache{entries: make(map[string]wildcardCacheEntry)}
+}
+
+func (w *wildcardCache) get(owner string, ttl time.Duration, now time.Time) ([]RepoConfig, bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	e, ok := w.entries[owner]
+	if !ok {
+		return nil, false
+	}
+	if now.Sub(e.resolved) > ttl {
+		return nil, false
+	}
+	// Return a copy so callers can't mutate the cache slice.
+	out := make([]RepoConfig, len(e.repos))
+	copy(out, e.repos)
+	return out, true
+}
+
+func (w *wildcardCache) put(owner string, repos []RepoConfig, now time.Time) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	stored := make([]RepoConfig, len(repos))
+	copy(stored, repos)
+	w.entries[owner] = wildcardCacheEntry{repos: stored, resolved: now}
+}
+
+// isWildcardSpec reports whether a RepoConfig is an OWNER/* spec that
+// needs to be expanded against the org-repos API. We only support
+// owner-level wildcards for now — path globs (foo/bar-*) are left for
+// a future iteration because GitHub's REST has no name-prefix filter.
+func isWildcardSpec(r RepoConfig) bool {
+	return r.Owner != "" && r.Name == "*"
+}
+
+// resolveRepos returns the effective list of repos to sync: explicit
+// entries are kept verbatim (component labels and all), and OWNER/*
+// entries are expanded via the GitHub org-repos endpoint. Explicit
+// entries are NOT deduplicated against wildcard expansions — operators
+// who write `OWNER/foo:my-component` alongside `OWNER/*` expect their
+// label to win, and a duplicate row downstream is harmless because
+// every PR is keyed by `owner/name#number` regardless of how many
+// RepoConfigs name the same repo.
+//
+// Failures on a single wildcard owner do not abort the whole sync; we
+// log via the caller's error path instead. (The Syncer.Sync loop is
+// already tolerant of partial repo-level failures — same contract.)
+func (s *Syncer) resolveRepos(ctx context.Context) ([]RepoConfig, error) {
+	if len(s.repos) == 0 {
+		return nil, nil
+	}
+	now := s.nowFn()
+	out := make([]RepoConfig, 0, len(s.repos))
+	for _, r := range s.repos {
+		if !isWildcardSpec(r) {
+			out = append(out, r)
+			continue
+		}
+		expanded, err := s.expandWildcard(ctx, r.Owner, now)
+		if err != nil {
+			return out, fmt.Errorf("expand wildcard %s/*: %w", r.Owner, err)
+		}
+		out = append(out, expanded...)
+	}
+	return out, nil
+}
+
+// expandWildcard returns the cached (or freshly fetched) expansion of
+// OWNER/*. Component labels default to empty for wildcard matches —
+// callers who want a specific label add an explicit
+// `OWNER/NAME:component` entry alongside the wildcard.
+func (s *Syncer) expandWildcard(ctx context.Context, owner string, now time.Time) ([]RepoConfig, error) {
+	if cached, ok := s.wildcardCache.get(owner, s.WildcardTTL, now); ok {
+		return cached, nil
+	}
+	repos, err := s.client.listOrgRepos(ctx, owner, s.IncludeArchived, s.IncludeForks)
+	if err != nil {
+		return nil, err
+	}
+	expanded := make([]RepoConfig, 0, len(repos))
+	for _, r := range repos {
+		expanded = append(expanded, RepoConfig{Owner: owner, Name: r.Name})
+	}
+	s.wildcardCache.put(owner, expanded, now)
+	return expanded, nil
+}
+
+// HasWildcardSpecs reports whether the syncer's configured repo list
+// contains any OWNER/* entries. Mostly useful for log lines and tests.
+func (s *Syncer) HasWildcardSpecs() bool {
+	for _, r := range s.repos {
+		if isWildcardSpec(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseWildcardOwner extracts the owner from "OWNER/*", returning ""
+// if the spec is not a wildcard. Exposed for parseRepos in main.go.
+func parseWildcardOwner(spec string) string {
+	owner, name, ok := strings.Cut(spec, "/")
+	if !ok || owner == "" || name != "*" {
+		return ""
+	}
+	return owner
+}
+
+// IsWildcardSpec is the exported analogue of isWildcardSpec, intended
+// for callers (e.g. cmd/server) that have a raw `owner/name` string
+// rather than a constructed RepoConfig.
+func IsWildcardSpec(spec string) bool { return parseWildcardOwner(spec) != "" }

--- a/roadmap-planner/backend/internal/storage/generic.go
+++ b/roadmap-planner/backend/internal/storage/generic.go
@@ -193,6 +193,16 @@ func (s *genericStore) UpsertPRReviews(ctx context.Context, reviews []PRReview) 
 // members
 // ----------------------------------------------------------------------
 
+// UpsertMember writes one member row. On conflict (existing id), Jira-
+// derived fields (display_name / email / jira_account_id / active) are
+// always overwritten with the latest value, while *operator-set* fields
+// (github_login, pillar_id) are preserved when the incoming row has them
+// empty. Without this guard, the Jira sync goroutine — which never reads
+// github_login or pillar_id — would clobber them every 30 minutes,
+// silently undoing any PATCH on /api/contributions/members/:id. The PATCH
+// endpoint always passes those fields explicitly, so its writes still
+// land (including intentional clears, which a future iteration would
+// signal differently — today an empty string from PATCH is "no change").
 func (s *genericStore) UpsertMember(ctx context.Context, m Member) error {
 	now := time.Now().UTC()
 	if m.CreatedAt.IsZero() {
@@ -210,8 +220,8 @@ func (s *genericStore) UpsertMember(ctx context.Context, m Member) error {
 			display_name = excluded.display_name,
 			email = excluded.email,
 			jira_account_id = excluded.jira_account_id,
-			github_login = excluded.github_login,
-			pillar_id = excluded.pillar_id,
+			github_login = COALESCE(NULLIF(excluded.github_login, ''), members.github_login),
+			pillar_id = COALESCE(NULLIF(excluded.pillar_id, ''), members.pillar_id),
 			active = excluded.active,
 			updated_at = excluded.updated_at`)
 	_, err := s.db.ExecContext(ctx, q,
@@ -219,6 +229,27 @@ func (s *genericStore) UpsertMember(ctx context.Context, m Member) error {
 		nullable(m.JiraAccountID), nullable(m.GitHubLogin),
 		nullable(m.PillarID), active, m.CreatedAt, m.UpdatedAt)
 	return err
+}
+
+// SetMemberIdentity is the literal-overwrite counterpart to UpsertMember.
+// Used by the PATCH endpoint, where explicit clears are meaningful.
+// All three fields land verbatim (empty string → NULL on the column);
+// updated_at is bumped.
+func (s *genericStore) SetMemberIdentity(ctx context.Context, id, displayName, githubLogin, pillarID string) error {
+	q := rebind(s.d, `
+		UPDATE members
+		   SET display_name = ?, github_login = ?, pillar_id = ?, updated_at = ?
+		 WHERE id = ?`)
+	res, err := s.db.ExecContext(ctx, q,
+		displayName, nullable(githubLogin), nullable(pillarID), time.Now().UTC(), id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
 }
 
 func (s *genericStore) ListMembers(ctx context.Context) ([]Member, error) {

--- a/roadmap-planner/backend/internal/storage/store.go
+++ b/roadmap-planner/backend/internal/storage/store.go
@@ -52,6 +52,12 @@ type Store interface {
 
 	// Members.
 	UpsertMember(ctx context.Context, m Member) error
+	// SetMemberIdentity writes the operator-editable identity fields
+	// (display_name, github_login, pillar_id) literally — empty values
+	// clear the field. Use for the PATCH /api/contributions/members/:id
+	// path, where UpsertMember's COALESCE-preserve semantics would
+	// silently drop an explicit clear.
+	SetMemberIdentity(ctx context.Context, id, displayName, githubLogin, pillarID string) error
 	ListMembers(ctx context.Context) ([]Member, error)
 
 	// Read paths used by the contributions service.

--- a/roadmap-planner/docs/team-analytics/PROPOSAL.md
+++ b/roadmap-planner/docs/team-analytics/PROPOSAL.md
@@ -529,6 +529,20 @@ Once backfill clears, incremental syncs only re-fetch PRs with
 `updated >= last_sync` — typically dozens per cycle, well below any
 limit.
 
+### Wildcard repo lists
+
+`github.repos` accepts an `OWNER/*` entry alongside (or instead of) a
+hand-curated list. At Sync time the Syncer walks
+`GET /orgs/{owner}/repos?per_page=100&type=all`, pages through, and
+treats every returned repo as if it had been listed individually. By
+default archived repos and forks are filtered out — both flags are
+togglable on the Syncer struct (`IncludeArchived`, `IncludeForks`).
+The resolved list is cached for `WildcardTTL` (24 h by default), so
+subsequent sync cycles inside that window skip the org-repos call
+entirely. Explicit `OWNER/NAME:component` entries still take effect
+when listed alongside `OWNER/*` — the explicit row keeps its component
+label, and the wildcard expansion is not deduplicated against it.
+
 ### Tests
 
 - `auth_test.go` — round-trips an App-installation-token mint via

--- a/roadmap-planner/frontend/src/components/TeamAnalytics.css
+++ b/roadmap-planner/frontend/src/components/TeamAnalytics.css
@@ -1,42 +1,33 @@
 /*
- * Team Analytics — visual language matches the prototype HTML in
- * docs/team-analytics/prototype.html. Editorial serif display + IBM
- * Plex Mono captions + restrained palette. Variables intentionally
- * shadow the existing app theme tokens so dark / Atlas / Platform
- * themes continue to work for free.
+ * Team Analytics — visual language tracks docs/team-analytics/prototype.html
+ * but is sourced ENTIRELY from the app's semantic theme tokens
+ * (see styles/theme.css). No hardcoded hex fallbacks: those break dark
+ * mode and the Atlas theme.
+ *
+ * Allowed tokens used here:
+ *   - colors:   --bg / --bg-elevated / --bg-sunken
+ *               --fg / --fg-muted / --fg-subtle / --fg-faint
+ *               --border / --border-soft
+ *               --accent / --accent-soft / --accent-tint
+ *               --ocean / --amber / --forest / --crimson (and -tint)
+ *   - typography: --font-ui / --font-display / --font-mono
+ *   - geometry:   --radius-default / --radius-sm / --radius-pill
+ *   - shadow:     --shadow-card / --shadow-plate
  */
 
 .ta-root {
-  --ta-bg:        var(--bg, #f8f6f1);
-  --ta-bg-elev:   var(--bg-elevated, #ffffff);
-  --ta-bg-soft:   var(--bg-soft, #f0ede5);
-  --ta-fg:        var(--fg, #1a1a1a);
-  --ta-fg-soft:   var(--fg-soft, #4a4a4a);
-  --ta-fg-muted:  var(--fg-muted, #888280);
-  --ta-border:    var(--border, #d8d2c4);
-  --ta-border-soft: var(--border-soft, #e6e2d6);
-  --ta-accent:    var(--accent, #b8443c);
-  --ta-accent-soft: var(--accent-soft, #efd9d4);
-  --ta-good:      #2f6b3a;
-  --ta-warn:      #b87a1a;
-  --ta-bad:       #b8443c;
-  --ta-info:      #2c5d75;
-  --ta-serif: var(--font-display, var(--font-serif, "Iowan Old Style", Georgia, serif));
-  --ta-mono:  var(--font-mono, "IBM Plex Mono", ui-monospace, monospace);
-  --ta-ui:    var(--font-ui, system-ui, -apple-system, sans-serif);
-
   padding: 28px 36px 80px;
   max-width: 1320px;
   margin: 0 auto;
-  font-family: var(--ta-ui);
+  font-family: var(--font-ui);
   font-size: 13px;
   line-height: 1.5;
-  color: var(--ta-fg);
+  color: var(--fg);
 }
 
 /* ---------- masthead ---------- */
 .ta-mast {
-  border-bottom: 1px solid var(--ta-border);
+  border-bottom: 1px solid var(--border);
   padding-bottom: 18px;
   margin-bottom: 22px;
   display: grid;
@@ -46,56 +37,65 @@
   flex-wrap: wrap;
 }
 .ta-mast__title {
-  font-family: var(--ta-serif);
+  font-family: var(--font-display);
   font-size: 32px;
   line-height: 1.1;
   letter-spacing: -0.01em;
   margin: 8px 0 0;
 }
-.ta-mast__title em { font-style: italic; color: var(--ta-accent); }
-.ta-mast__sub  {
-  font-family: var(--ta-mono);
+.ta-mast__title em {
+  font-style: var(--display-style, normal);
+  color: var(--accent);
+}
+.ta-mast__sub {
+  font-family: var(--font-mono);
   font-size: 10.5px;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--ta-fg-muted);
+  color: var(--fg-muted);
   margin-top: 6px;
 }
 .ta-mast__bracket {
   display: inline-block;
   padding: 3px 8px 4px;
-  border: 1px solid var(--ta-border);
-  border-radius: 2px;
-  font-family: var(--ta-mono);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 2px);
+  font-family: var(--font-mono);
   font-size: 10.5px;
   letter-spacing: 0.18em;
-  color: var(--ta-fg-soft);
+  color: var(--fg-subtle);
 }
-.ta-mast__meta { font-family: var(--ta-mono); font-size: 10.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--ta-fg-muted); }
-.ta-mast__meta strong { color: var(--ta-fg-soft); font-weight: 500; }
+.ta-mast__meta {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.ta-mast__meta strong { color: var(--fg-subtle); font-weight: 500; }
 
 .ta-status { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 6px; }
 .ta-badge {
   display: inline-flex;
   align-items: center;
   padding: 4px 10px;
-  border: 1px solid var(--ta-border);
-  border-radius: 999px;
-  font-family: var(--ta-mono);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill, 999px);
+  font-family: var(--font-mono);
   font-size: 10.5px;
   letter-spacing: 0.04em;
-  color: var(--ta-fg-soft);
-  background: var(--ta-bg-elev);
+  color: var(--fg-subtle);
+  background: var(--bg-elevated);
 }
-.ta-badge--ok   { border-color: #6cb073; }
-.ta-badge--warn { border-color: var(--ta-warn); }
-.ta-badge--bad  { border-color: var(--ta-bad); color: var(--ta-bad); }
+.ta-badge--ok   { border-color: var(--forest); }
+.ta-badge--warn { border-color: var(--amber); color: var(--amber); }
+.ta-badge--bad  { border-color: var(--crimson); color: var(--crimson); }
 
 /* ---------- tabs ---------- */
 .ta-tabs {
   display: flex;
   gap: 0;
-  border-bottom: 1px solid var(--ta-border);
+  border-bottom: 1px solid var(--border);
   margin-bottom: 22px;
   flex-wrap: wrap;
 }
@@ -104,37 +104,59 @@
   border: 0;
   border-bottom: 2px solid transparent;
   padding: 10px 18px 12px;
-  font-family: var(--ta-ui);
+  font-family: var(--font-ui);
   font-size: 13px;
-  color: var(--ta-fg-muted);
+  color: var(--fg-muted);
   cursor: pointer;
   letter-spacing: 0.02em;
 }
-.ta-tab:hover:not(:disabled) { color: var(--ta-fg-soft); }
-.ta-tab.is-active { color: var(--ta-fg); border-bottom-color: var(--ta-accent); font-weight: 500; }
-.ta-tab__num { font-family: var(--ta-mono); font-size: 10.5px; letter-spacing: 0.16em; color: var(--ta-fg-muted); margin-right: 8px; }
-.ta-tab.is-active .ta-tab__num { color: var(--ta-accent); }
+.ta-tab:hover:not(:disabled) { color: var(--fg-subtle); }
+.ta-tab.is-active {
+  color: var(--fg);
+  border-bottom-color: var(--accent);
+  font-weight: 500;
+}
+.ta-tab__num {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.16em;
+  color: var(--fg-faint);
+  margin-right: 8px;
+}
+.ta-tab.is-active .ta-tab__num { color: var(--accent); }
 .ta-tab:disabled { cursor: not-allowed; opacity: 0.5; }
 
 /* ---------- panels ---------- */
 .ta-panel {
-  background: var(--ta-bg-elev);
-  border: 1px solid var(--ta-border-soft);
-  border-radius: 4px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-default, 4px);
   overflow: hidden;
+  box-shadow: var(--shadow-card);
 }
 .ta-panel__head {
   padding: 14px 18px;
-  border-bottom: 1px solid var(--ta-border-soft);
+  border-bottom: 1px solid var(--border-soft);
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  background: var(--ta-bg-soft);
+  background: var(--bg-sunken);
   flex-wrap: wrap;
   gap: 10px;
 }
-.ta-panel__title { font-family: var(--ta-serif); font-size: 18px; }
-.ta-panel__sub   { font-family: var(--ta-mono); font-size: 10.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--ta-fg-muted); }
+.ta-panel__title {
+  font-family: var(--font-display);
+  font-style: var(--display-style, normal);
+  font-weight: var(--display-weight, 600);
+  font-size: 18px;
+}
+.ta-panel__sub {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
 
 /* ---------- filter pills ---------- */
 .ta-filters {
@@ -144,47 +166,58 @@
   flex-wrap: wrap;
 }
 .ta-filters__lbl {
-  font-family: var(--ta-mono);
+  font-family: var(--font-mono);
   font-size: 10.5px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--ta-fg-muted);
+  color: var(--fg-muted);
 }
 .ta-pill {
   display: inline-block;
   padding: 2px 9px;
-  border: 1px solid var(--ta-border);
-  border-radius: 999px;
-  font-family: var(--ta-mono);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill, 999px);
+  font-family: var(--font-mono);
   font-size: 10.5px;
-  color: var(--ta-fg-soft);
+  color: var(--fg-subtle);
   cursor: pointer;
   user-select: none;
   background: transparent;
 }
-.ta-pill.is-active { background: var(--ta-fg); color: var(--ta-bg-elev); border-color: var(--ta-fg); }
+.ta-pill:hover { color: var(--fg); border-color: var(--fg-faint); }
+.ta-pill.is-active {
+  background: var(--fg);
+  color: var(--bg-elevated);
+  border-color: var(--fg);
+}
 
-.ta-seg { display: inline-flex; border: 1px solid var(--ta-border); border-radius: 3px; overflow: hidden; }
+.ta-seg {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 3px);
+  overflow: hidden;
+}
 .ta-seg button {
   background: transparent;
   border: 0;
-  border-right: 1px solid var(--ta-border);
+  border-right: 1px solid var(--border);
   padding: 5px 10px;
-  font-family: var(--ta-mono);
+  font-family: var(--font-mono);
   font-size: 11px;
   cursor: pointer;
-  color: var(--ta-fg-soft);
+  color: var(--fg-subtle);
 }
 .ta-seg button:last-child { border-right: 0; }
-.ta-seg button.is-active { background: var(--ta-fg); color: var(--ta-bg-elev); }
+.ta-seg button:hover { color: var(--fg); }
+.ta-seg button.is-active { background: var(--fg); color: var(--bg-elevated); }
 
 .ta-slice-filters {
   display: flex;
   gap: 10px;
   align-items: center;
   padding: 14px 18px;
-  border-bottom: 1px solid var(--ta-border-soft);
-  background: #fbf9f4;
+  border-bottom: 1px solid var(--border-soft);
+  background: var(--bg-sunken);
   flex-wrap: wrap;
 }
 
@@ -193,132 +226,209 @@
 .ta-tbl th {
   text-align: left;
   padding: 10px 14px;
-  font-family: var(--ta-mono);
+  font-family: var(--font-mono);
   font-size: 10.5px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--ta-fg-muted);
-  background: #fbf9f4;
-  border-bottom: 1px solid var(--ta-border-soft);
+  color: var(--fg-muted);
+  background: var(--bg-sunken);
+  border-bottom: 1px solid var(--border-soft);
   cursor: pointer;
   white-space: nowrap;
   user-select: none;
 }
-.ta-tbl th:hover { color: var(--ta-fg-soft); }
-.ta-tbl th.is-sorted { color: var(--ta-accent); }
+.ta-tbl th:hover { color: var(--fg-subtle); }
+.ta-tbl th.is-sorted { color: var(--accent); }
 .ta-tbl th.no-sort { cursor: default; }
 .ta-tbl th.right { text-align: right; }
 .ta-tbl td {
   padding: 14px;
-  border-bottom: 1px solid var(--ta-border-soft);
+  border-bottom: 1px solid var(--border-soft);
   vertical-align: middle;
+  color: var(--fg);
 }
 .ta-tbl tr:last-child td { border-bottom: 0; }
-.ta-tbl tr.row-link:hover { background: var(--ta-bg-soft); cursor: pointer; }
+.ta-tbl tr.row-link:hover { background: var(--bg-sunken); cursor: pointer; }
 .ta-tbl tr.is-inactive { opacity: 0.55; }
 
 .ta-cell-member { display: flex; align-items: center; gap: 12px; }
 .ta-avatar {
   width: 30px; height: 30px;
   border-radius: 50%;
-  background: var(--ta-accent-soft);
-  color: var(--ta-accent);
+  background: var(--accent-soft);
+  color: var(--accent);
   display: inline-flex;
   align-items: center; justify-content: center;
-  font-family: var(--ta-mono);
+  font-family: var(--font-mono);
   font-size: 10.5px;
   font-weight: 600;
-  border: 1px solid var(--ta-border);
+  border: 1px solid var(--border);
   flex-shrink: 0;
 }
-.ta-name { font-weight: 500; font-size: 13.5px; }
-.ta-meta { font-family: var(--ta-mono); font-size: 10.5px; color: var(--ta-fg-muted); letter-spacing: 0.04em; }
+.ta-name { font-weight: 500; font-size: 13.5px; color: var(--fg); }
+.ta-meta {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--fg-muted);
+  letter-spacing: 0.04em;
+}
 
-.ta-num { font-family: var(--ta-mono); font-size: 14px; font-variant-numeric: tabular-nums; }
-.ta-num--lg { font-size: 22px; font-family: var(--ta-serif); }
+.ta-num {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg);
+}
+.ta-num--lg { font-size: 22px; font-family: var(--font-display); }
 .ta-right { text-align: right; }
-.ta-delta { display: inline-block; margin-left: 6px; font-family: var(--ta-mono); font-size: 11px; }
-.ta-delta.up { color: var(--ta-good); }
-.ta-delta.down { color: var(--ta-bad); }
-.ta-delta.flat { color: var(--ta-fg-muted); }
+.ta-delta { display: inline-block; margin-left: 6px; font-family: var(--font-mono); font-size: 11px; }
+.ta-delta.up { color: var(--forest); }
+.ta-delta.down { color: var(--crimson); }
+.ta-delta.flat { color: var(--fg-muted); }
 
-.ta-spark { display: block; color: var(--ta-accent); }
+.ta-spark { display: block; color: var(--accent); }
 
 /* ---------- 2-up grid (team tab bottom panels) ---------- */
 .ta-row { display: grid; grid-template-columns: 1.6fr 1fr; gap: 18px; margin-top: 22px; }
-.ta-rule { height: 1px; background: var(--ta-border-soft); margin: 22px 0; border: 0; }
+.ta-rule { height: 1px; background: var(--border-soft); margin: 22px 0; border: 0; }
 
 /* ---------- chart helpers ---------- */
-.ta-chartwrap { padding: 22px; }
-.ta-chartwrap--small { padding: 18px 22px; }
+.ta-chartwrap { padding: 22px; background: var(--bg-elevated); }
+.ta-chartwrap--small { padding: 18px 22px; background: var(--bg-elevated); }
 
 .ta-legend {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  font-family: var(--ta-mono);
+  gap: 14px;
+  font-family: var(--font-mono);
   font-size: 10.5px;
   letter-spacing: 0.08em;
-  color: var(--ta-fg-muted);
+  color: var(--fg-muted);
   flex-wrap: wrap;
 }
-.ta-legend i { display: inline-block; width: 10px; height: 10px; border-radius: 2px; vertical-align: -1px; margin-right: 4px; }
+.ta-legend i { display: inline-block; width: 10px; height: 10px; border-radius: var(--radius-sm, 2px); vertical-align: -1px; margin-right: 4px; }
 
 .ta-chart-svg { display: block; width: 100%; }
-.ta-chart-axis { font-family: var(--ta-mono); font-size: 9.5px; fill: var(--ta-fg-muted); }
-.ta-chart-grid { stroke: var(--ta-border-soft); stroke-width: 1; }
+.ta-chart-axis {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  fill: var(--fg-muted);
+}
+.ta-chart-grid { stroke: var(--border-soft); stroke-width: 1; }
 
-.ta-fact { font-family: var(--ta-serif); font-size: 14px; color: var(--ta-fg-soft); margin: 0; }
-.ta-fact strong { color: var(--ta-fg); }
-.ta-bullets { margin-top: 16px; display: flex; flex-direction: column; gap: 6px; font-family: var(--ta-mono); font-size: 11px; color: var(--ta-fg-soft); }
-.ta-bullets b { color: var(--ta-fg); font-weight: 500; }
+.ta-fact {
+  font-family: var(--font-display);
+  font-style: var(--display-style, normal);
+  font-weight: var(--display-weight, 400);
+  font-size: 14px;
+  color: var(--fg-subtle);
+  margin: 0;
+  line-height: 1.5;
+}
+.ta-fact strong { color: var(--fg); font-weight: 600; }
+.ta-fact code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--bg-sunken);
+  padding: 1px 5px;
+  border-radius: var(--radius-sm, 2px);
+}
+.ta-bullets {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-subtle);
+}
+.ta-bullets b { color: var(--fg); font-weight: 500; }
 
 /* ---------- member profile ---------- */
 .ta-profile-grid { display: grid; grid-template-columns: 280px 1fr; gap: 20px; }
 .ta-profile-card {
   padding: 22px;
-  border: 1px solid var(--ta-border-soft);
-  border-radius: 4px;
-  background: var(--ta-bg-elev);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-default, 4px);
+  background: var(--bg-elevated);
+  box-shadow: var(--shadow-card);
 }
 .ta-profile-avatar {
   width: 64px; height: 64px;
   border-radius: 50%;
-  background: var(--ta-accent-soft);
-  color: var(--ta-accent);
+  background: var(--accent-soft);
+  color: var(--accent);
   display: inline-flex;
   align-items: center; justify-content: center;
-  font-family: var(--ta-mono);
+  font-family: var(--font-mono);
   font-size: 18px;
   font-weight: 600;
-  border: 1px solid var(--ta-border);
+  border: 1px solid var(--border);
 }
-.ta-profile-name { font-family: var(--ta-serif); font-size: 24px; margin-top: 14px; line-height: 1.15; }
-.ta-profile-pillar { font-family: var(--ta-mono); font-size: 10.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--ta-fg-muted); margin-top: 4px; }
-.ta-profile-handles { margin-top: 12px; font-family: var(--ta-mono); font-size: 11px; color: var(--ta-fg-soft); }
+.ta-profile-name {
+  font-family: var(--font-display);
+  font-style: var(--display-style, normal);
+  font-weight: var(--display-weight, 600);
+  font-size: 24px;
+  margin-top: 14px;
+  line-height: 1.15;
+  color: var(--fg);
+}
+.ta-profile-pillar {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin-top: 4px;
+}
+.ta-profile-handles {
+  margin-top: 12px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-subtle);
+}
 .ta-profile-handles div { padding: 1px 0; }
+.ta-profile-handles em { color: var(--fg-muted); font-style: normal; }
+.ta-profile-handles span.gh { color: var(--accent); }
 
 .ta-kpi-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 1px;
-  background: var(--ta-border-soft);
+  background: var(--border-soft);
   margin: 18px -22px -22px;
-  border-top: 1px solid var(--ta-border-soft);
+  border-top: 1px solid var(--border-soft);
 }
-.ta-kpi { background: var(--ta-bg-elev); padding: 14px 18px; }
-.ta-kpi__lbl { font-family: var(--ta-mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ta-fg-muted); }
-.ta-kpi__val { font-family: var(--ta-serif); font-size: 26px; margin-top: 4px; }
+.ta-kpi { background: var(--bg-elevated); padding: 14px 18px; }
+.ta-kpi__lbl {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.ta-kpi__val {
+  font-family: var(--font-display);
+  font-style: var(--display-style, normal);
+  font-weight: var(--display-weight, 600);
+  font-size: 26px;
+  margin-top: 4px;
+  color: var(--fg);
+}
 
 .ta-card {
-  background: var(--ta-bg-elev);
-  border: 1px solid var(--ta-border-soft);
-  border-radius: 4px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-default, 4px);
   padding: 18px 22px;
+  box-shadow: var(--shadow-card);
 }
 .ta-card + .ta-card { margin-top: 14px; }
 .ta-card__title {
-  font-family: var(--ta-serif);
+  font-family: var(--font-display);
+  font-style: var(--display-style, normal);
+  font-weight: var(--display-weight, 600);
   font-size: 16px;
   margin: 0 0 4px;
   display: flex;
@@ -326,13 +436,14 @@
   align-items: baseline;
   flex-wrap: wrap;
   gap: 8px;
+  color: var(--fg);
 }
 .ta-card__sub {
-  font-family: var(--ta-mono);
+  font-family: var(--font-mono);
   font-size: 10.5px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--ta-fg-muted);
+  color: var(--fg-muted);
   margin-bottom: 12px;
 }
 
@@ -343,10 +454,24 @@
   gap: 10px;
   padding: 4px 0;
 }
-.ta-bar-label { font-family: var(--ta-mono); font-size: 11.5px; color: var(--ta-fg-soft); }
-.ta-bar-track { height: 12px; background: var(--ta-bg-soft); border-radius: 2px; overflow: hidden; }
-.ta-bar-fill { height: 100%; background: var(--ta-accent); }
-.ta-bar-num { text-align: right; font-family: var(--ta-mono); font-size: 11.5px; }
+.ta-bar-label {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--fg-subtle);
+}
+.ta-bar-track {
+  height: 12px;
+  background: var(--bg-sunken);
+  border-radius: var(--radius-sm, 2px);
+  overflow: hidden;
+}
+.ta-bar-fill { height: 100%; background: var(--accent); }
+.ta-bar-num {
+  text-align: right;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--fg);
+}
 
 .ta-sprint-grid {
   display: grid;
@@ -359,15 +484,15 @@
 .ta-backlink {
   background: transparent;
   border: 0;
-  font-family: var(--ta-mono);
+  font-family: var(--font-mono);
   font-size: 10.5px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--ta-fg-muted);
+  color: var(--fg-muted);
   cursor: pointer;
   padding: 0 0 14px;
 }
-.ta-backlink:hover { color: var(--ta-accent); }
+.ta-backlink:hover { color: var(--accent); }
 
 /* ---------- profile edit form ---------- */
 .ta-edit-grid {
@@ -377,31 +502,37 @@
 }
 .ta-field { display: flex; flex-direction: column; gap: 4px; }
 .ta-field-label {
-  font-family: var(--ta-mono);
+  font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--ta-fg-muted);
+  color: var(--fg-muted);
 }
 .ta-field-help {
-  font-family: var(--ta-mono);
+  font-family: var(--font-mono);
   font-size: 10px;
-  color: var(--ta-fg-muted);
+  color: var(--fg-muted);
   margin-top: 2px;
   letter-spacing: 0.02em;
 }
 .ta-input {
   font: inherit;
-  font-family: var(--ta-mono);
+  font-family: var(--font-mono);
   font-size: 13px;
   padding: 7px 10px;
-  background: var(--ta-bg-elev);
-  border: 1px solid var(--ta-border);
-  border-radius: 3px;
-  color: var(--ta-fg);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 3px);
+  color: var(--fg);
 }
-.ta-input:focus { outline: 2px solid var(--ta-accent); outline-offset: -2px; }
-.ta-input--ro { background: var(--ta-bg-soft); color: var(--ta-fg-soft); }
+.ta-input:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.ta-input--ro {
+  background: var(--bg-sunken);
+  color: var(--fg-muted);
+}
 
 .ta-form-actions {
   display: flex;
@@ -411,103 +542,130 @@
   margin-top: 12px;
 }
 .ta-btn {
-  font-family: var(--ta-mono);
+  font-family: var(--font-mono);
   font-size: 11px;
   letter-spacing: 0.16em;
   text-transform: uppercase;
   padding: 7px 14px;
-  border-radius: 3px;
+  border-radius: var(--radius-sm, 3px);
   cursor: pointer;
-  border: 1px solid var(--ta-border);
-  background: var(--ta-bg-elev);
-  color: var(--ta-fg-soft);
+  border: 1px solid var(--border);
+  background: var(--bg-elevated);
+  color: var(--fg-subtle);
 }
-.ta-btn:hover:not(:disabled) { color: var(--ta-fg); }
+.ta-btn:hover:not(:disabled) {
+  color: var(--fg);
+  background: var(--bg-sunken);
+  border-color: var(--fg-faint);
+}
 .ta-btn--primary {
-  background: var(--ta-accent);
-  border-color: var(--ta-accent);
+  background: var(--accent);
+  border-color: var(--accent);
   color: #fff;
 }
 .ta-btn--primary:disabled { opacity: 0.5; cursor: not-allowed; }
-.ta-btn--primary:hover:not(:disabled) { background: #9b3933; color: #fff; }
+.ta-btn--primary:hover:not(:disabled) {
+  filter: brightness(0.92);
+  background: var(--accent);
+  color: #fff;
+}
 
 /* ---------- pivot table (Slice Explorer) ---------- */
-.ta-pivot-wrap { overflow-x: auto; }
+.ta-pivot-wrap { overflow-x: auto; background: var(--bg-elevated); }
 .ta-pivot { width: 100%; border-collapse: collapse; }
 .ta-pivot th, .ta-pivot td {
   padding: 8px 10px;
-  font-family: var(--ta-mono);
+  font-family: var(--font-mono);
   font-size: 11.5px;
   text-align: right;
   font-variant-numeric: tabular-nums;
-  border-bottom: 1px solid var(--ta-border-soft);
+  border-bottom: 1px solid var(--border-soft);
+  color: var(--fg);
 }
 .ta-pivot th {
-  background: #fbf9f4;
-  color: var(--ta-fg-muted);
+  background: var(--bg-sunken);
+  color: var(--fg-muted);
   letter-spacing: 0.08em;
   text-transform: uppercase;
   font-size: 10px;
 }
 .ta-pivot td:first-child, .ta-pivot th:first-child {
   text-align: left;
-  font-family: var(--ta-serif);
+  font-family: var(--font-display);
+  font-style: var(--display-style, normal);
+  font-weight: var(--display-weight, 500);
   font-size: 13.5px;
   text-transform: none;
   letter-spacing: 0;
-  color: var(--ta-fg);
+  color: var(--fg);
   white-space: nowrap;
 }
 .ta-pivot td.heat {
   position: relative;
-  color: var(--ta-fg);
+  color: var(--fg);
 }
 .ta-pivot td.heat::before {
   content: ""; position: absolute; inset: 2px 1px;
-  background: var(--ta-accent);
+  background: var(--accent);
   opacity: var(--h, 0);
-  border-radius: 2px;
+  border-radius: var(--radius-sm, 2px);
   z-index: 0;
 }
 .ta-pivot td.heat span { position: relative; z-index: 1; }
-.ta-pivot td.heat-zero { color: var(--ta-fg-muted); }
+.ta-pivot td.heat-zero { color: var(--fg-muted); }
 
 .ta-pivot-foot {
   padding: 14px 18px;
-  font-family: var(--ta-mono);
+  font-family: var(--font-mono);
   font-size: 10.5px;
-  color: var(--ta-fg-muted);
-  border-top: 1px solid var(--ta-border-soft);
+  color: var(--fg-muted);
+  border-top: 1px solid var(--border-soft);
+  background: var(--bg-elevated);
 }
 
 /* ---------- empty / banner ---------- */
 .ta-empty {
   padding: 48px 32px;
   text-align: center;
-  background: var(--ta-bg-elev);
-  border: 1px dashed var(--ta-border);
-  border-radius: 4px;
+  background: var(--bg-elevated);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-default, 4px);
 }
-.ta-empty h3 { font-family: var(--ta-serif); font-size: 18px; margin: 0 0 8px; }
-.ta-empty p { font-size: 13px; color: var(--ta-fg-soft); max-width: 540px; margin: 4px auto; }
-.ta-empty a { color: var(--ta-accent); }
+.ta-empty h3 {
+  font-family: var(--font-display);
+  font-style: var(--display-style, normal);
+  font-weight: var(--display-weight, 600);
+  font-size: 18px;
+  margin: 0 0 8px;
+  color: var(--fg);
+}
+.ta-empty p { font-size: 13px; color: var(--fg-subtle); max-width: 540px; margin: 4px auto; }
+.ta-empty a { color: var(--accent); }
 
 .ta-banner {
   padding: 10px 14px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm, 3px);
   font-size: 13px;
   margin-bottom: 16px;
 }
-.ta-banner--bad  { background: #fdf1f0; border: 1px solid #f3c8c4; color: #8d2a23; }
-.ta-banner--info { background: var(--ta-bg-soft); border: 1px dashed var(--ta-border); color: var(--ta-fg-soft); }
+.ta-banner--bad {
+  background: var(--crimson-tint);
+  border: 1px solid var(--crimson-soft);
+  color: var(--crimson);
+}
+.ta-banner--info {
+  background: var(--bg-sunken);
+  border: 1px dashed var(--border);
+  color: var(--fg-subtle);
+}
 
 .ta-loading {
   padding: 16px;
   text-align: center;
-  font-family: var(--ta-mono);
+  font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--ta-fg-muted);
-  border-top: 1px solid var(--ta-border-soft);
+  color: var(--fg-muted);
+  border-top: 1px solid var(--border-soft);
 }
 
 /* ---------- responsive ---------- */

--- a/roadmap-planner/frontend/src/components/TeamAnalytics.css
+++ b/roadmap-planner/frontend/src/components/TeamAnalytics.css
@@ -1,144 +1,496 @@
 /*
- * Team Analytics — visual language matches the rest of the Atlas /
- * Platform editions: serif display, mono captions, restrained palette.
- * All colours come from the existing CSS-vars system in App.css so we
- * inherit the dark/light + theme switches for free.
+ * Team Analytics — visual language matches the prototype HTML in
+ * docs/team-analytics/prototype.html. Editorial serif display + IBM
+ * Plex Mono captions + restrained palette. Variables intentionally
+ * shadow the existing app theme tokens so dark / Atlas / Platform
+ * themes continue to work for free.
  */
+
 .ta-root {
-  padding: 22px 24px 80px;
-  max-width: 1280px;
+  --ta-bg:        var(--bg, #f8f6f1);
+  --ta-bg-elev:   var(--bg-elevated, #ffffff);
+  --ta-bg-soft:   var(--bg-soft, #f0ede5);
+  --ta-fg:        var(--fg, #1a1a1a);
+  --ta-fg-soft:   var(--fg-soft, #4a4a4a);
+  --ta-fg-muted:  var(--fg-muted, #888280);
+  --ta-border:    var(--border, #d8d2c4);
+  --ta-border-soft: var(--border-soft, #e6e2d6);
+  --ta-accent:    var(--accent, #b8443c);
+  --ta-accent-soft: var(--accent-soft, #efd9d4);
+  --ta-good:      #2f6b3a;
+  --ta-warn:      #b87a1a;
+  --ta-bad:       #b8443c;
+  --ta-info:      #2c5d75;
+  --ta-serif: var(--font-display, var(--font-serif, "Iowan Old Style", Georgia, serif));
+  --ta-mono:  var(--font-mono, "IBM Plex Mono", ui-monospace, monospace);
+  --ta-ui:    var(--font-ui, system-ui, -apple-system, sans-serif);
+
+  padding: 28px 36px 80px;
+  max-width: 1320px;
   margin: 0 auto;
-  font-family: var(--font-ui, system-ui, sans-serif);
-  color: var(--fg, #1a1a1a);
+  font-family: var(--ta-ui);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--ta-fg);
 }
 
-.ta-head {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  gap: 16px;
-  border-bottom: 1px solid var(--border, #d8d2c4);
+/* ---------- masthead ---------- */
+.ta-mast {
+  border-bottom: 1px solid var(--ta-border);
   padding-bottom: 18px;
   margin-bottom: 22px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: end;
+  gap: 18px;
   flex-wrap: wrap;
 }
-.ta-eyebrow {
-  font-family: var(--font-mono, monospace);
+.ta-mast__title {
+  font-family: var(--ta-serif);
+  font-size: 32px;
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin: 8px 0 0;
+}
+.ta-mast__title em { font-style: italic; color: var(--ta-accent); }
+.ta-mast__sub  {
+  font-family: var(--ta-mono);
   font-size: 10.5px;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--fg-muted, #888280);
+  color: var(--ta-fg-muted);
+  margin-top: 6px;
 }
-.ta-title {
-  font-family: var(--font-display, var(--font-serif, serif));
-  font-size: 28px;
-  line-height: 1.1;
-  letter-spacing: -0.01em;
-  margin: 6px 0 4px;
+.ta-mast__bracket {
+  display: inline-block;
+  padding: 3px 8px 4px;
+  border: 1px solid var(--ta-border);
+  border-radius: 2px;
+  font-family: var(--ta-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.18em;
+  color: var(--ta-fg-soft);
 }
-.ta-sub {
-  font-family: var(--font-mono, monospace);
-  font-size: 11px;
-  letter-spacing: 0.04em;
-  color: var(--fg-muted, #888280);
-  margin: 0;
-}
+.ta-mast__meta { font-family: var(--ta-mono); font-size: 10.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--ta-fg-muted); }
+.ta-mast__meta strong { color: var(--ta-fg-soft); font-weight: 500; }
 
-.ta-status { display: flex; gap: 8px; flex-wrap: wrap; }
+.ta-status { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 6px; }
 .ta-badge {
   display: inline-flex;
   align-items: center;
   padding: 4px 10px;
-  border: 1px solid var(--border, #d8d2c4);
+  border: 1px solid var(--ta-border);
   border-radius: 999px;
-  font-family: var(--font-mono, monospace);
+  font-family: var(--ta-mono);
   font-size: 10.5px;
   letter-spacing: 0.04em;
-  color: var(--fg-soft, #4a4a4a);
-  background: var(--bg-elevated, #fff);
+  color: var(--ta-fg-soft);
+  background: var(--ta-bg-elev);
 }
 .ta-badge--ok   { border-color: #6cb073; }
-.ta-badge--warn { border-color: #d6a458; color: var(--fg-soft, #4a4a4a); }
-.ta-badge--bad  { border-color: #b8443c; color: #b8443c; }
+.ta-badge--warn { border-color: var(--ta-warn); }
+.ta-badge--bad  { border-color: var(--ta-bad); color: var(--ta-bad); }
 
-/* ---------- panel + table ---------- */
+/* ---------- tabs ---------- */
+.ta-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--ta-border);
+  margin-bottom: 22px;
+  flex-wrap: wrap;
+}
+.ta-tab {
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  padding: 10px 18px 12px;
+  font-family: var(--ta-ui);
+  font-size: 13px;
+  color: var(--ta-fg-muted);
+  cursor: pointer;
+  letter-spacing: 0.02em;
+}
+.ta-tab:hover:not(:disabled) { color: var(--ta-fg-soft); }
+.ta-tab.is-active { color: var(--ta-fg); border-bottom-color: var(--ta-accent); font-weight: 500; }
+.ta-tab__num { font-family: var(--ta-mono); font-size: 10.5px; letter-spacing: 0.16em; color: var(--ta-fg-muted); margin-right: 8px; }
+.ta-tab.is-active .ta-tab__num { color: var(--ta-accent); }
+.ta-tab:disabled { cursor: not-allowed; opacity: 0.5; }
+
+/* ---------- panels ---------- */
 .ta-panel {
-  background: var(--bg-elevated, #fff);
-  border: 1px solid var(--border-soft, #e6e2d6);
+  background: var(--ta-bg-elev);
+  border: 1px solid var(--ta-border-soft);
   border-radius: 4px;
   overflow: hidden;
 }
-.ta-table {
-  width: 100%;
-  border-collapse: collapse;
+.ta-panel__head {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--ta-border-soft);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  background: var(--ta-bg-soft);
+  flex-wrap: wrap;
+  gap: 10px;
 }
-.ta-th {
-  text-align: left;
-  padding: 10px 14px;
-  font-family: var(--font-mono, monospace);
+.ta-panel__title { font-family: var(--ta-serif); font-size: 18px; }
+.ta-panel__sub   { font-family: var(--ta-mono); font-size: 10.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--ta-fg-muted); }
+
+/* ---------- filter pills ---------- */
+.ta-filters {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.ta-filters__lbl {
+  font-family: var(--ta-mono);
   font-size: 10.5px;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--fg-muted, #888280);
-  background: var(--bg-soft, #f0ede5);
-  border-bottom: 1px solid var(--border-soft, #e6e2d6);
-  user-select: none;
-  white-space: nowrap;
+  color: var(--ta-fg-muted);
 }
-.ta-th--right { text-align: right; }
-.ta-th.is-sortable { cursor: pointer; }
-.ta-th.is-sortable:hover { color: var(--fg-soft, #4a4a4a); }
-.ta-th.is-sorted { color: var(--accent, #b8443c); }
-.ta-arrow { display: inline-block; margin-left: 4px; font-family: inherit; }
+.ta-pill {
+  display: inline-block;
+  padding: 2px 9px;
+  border: 1px solid var(--ta-border);
+  border-radius: 999px;
+  font-family: var(--ta-mono);
+  font-size: 10.5px;
+  color: var(--ta-fg-soft);
+  cursor: pointer;
+  user-select: none;
+  background: transparent;
+}
+.ta-pill.is-active { background: var(--ta-fg); color: var(--ta-bg-elev); border-color: var(--ta-fg); }
 
-.ta-td {
-  padding: 12px 14px;
-  border-bottom: 1px solid var(--border-soft, #e6e2d6);
+.ta-seg { display: inline-flex; border: 1px solid var(--ta-border); border-radius: 3px; overflow: hidden; }
+.ta-seg button {
+  background: transparent;
+  border: 0;
+  border-right: 1px solid var(--ta-border);
+  padding: 5px 10px;
+  font-family: var(--ta-mono);
+  font-size: 11px;
+  cursor: pointer;
+  color: var(--ta-fg-soft);
+}
+.ta-seg button:last-child { border-right: 0; }
+.ta-seg button.is-active { background: var(--ta-fg); color: var(--ta-bg-elev); }
+
+.ta-slice-filters {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--ta-border-soft);
+  background: #fbf9f4;
+  flex-wrap: wrap;
+}
+
+/* ---------- table ---------- */
+.ta-tbl { width: 100%; border-collapse: collapse; }
+.ta-tbl th {
+  text-align: left;
+  padding: 10px 14px;
+  font-family: var(--ta-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ta-fg-muted);
+  background: #fbf9f4;
+  border-bottom: 1px solid var(--ta-border-soft);
+  cursor: pointer;
+  white-space: nowrap;
+  user-select: none;
+}
+.ta-tbl th:hover { color: var(--ta-fg-soft); }
+.ta-tbl th.is-sorted { color: var(--ta-accent); }
+.ta-tbl th.no-sort { cursor: default; }
+.ta-tbl th.right { text-align: right; }
+.ta-tbl td {
+  padding: 14px;
+  border-bottom: 1px solid var(--ta-border-soft);
   vertical-align: middle;
 }
-.ta-table tr:last-child .ta-td { border-bottom: 0; }
-.ta-td--right { text-align: right; }
-.ta-td--member { display: flex; align-items: center; gap: 12px; }
-.mono { font-family: var(--font-mono, monospace); font-variant-numeric: tabular-nums; }
+.ta-tbl tr:last-child td { border-bottom: 0; }
+.ta-tbl tr.row-link:hover { background: var(--ta-bg-soft); cursor: pointer; }
+.ta-tbl tr.is-inactive { opacity: 0.55; }
 
+.ta-cell-member { display: flex; align-items: center; gap: 12px; }
 .ta-avatar {
   width: 30px; height: 30px;
   border-radius: 50%;
-  background: var(--accent-soft, #efd9d4);
-  color: var(--accent, #b8443c);
+  background: var(--ta-accent-soft);
+  color: var(--ta-accent);
   display: inline-flex;
   align-items: center; justify-content: center;
-  font-family: var(--font-mono, monospace);
+  font-family: var(--ta-mono);
   font-size: 10.5px;
   font-weight: 600;
-  border: 1px solid var(--border, #d8d2c4);
+  border: 1px solid var(--ta-border);
   flex-shrink: 0;
 }
-
 .ta-name { font-weight: 500; font-size: 13.5px; }
-.ta-meta { font-size: 10.5px; color: var(--fg-muted, #888280); }
+.ta-meta { font-family: var(--ta-mono); font-size: 10.5px; color: var(--ta-fg-muted); letter-spacing: 0.04em; }
 
-.ta-spark { display: block; color: var(--accent, #b8443c); }
-.ta-spark--empty { font-family: var(--font-mono, monospace); color: var(--fg-muted, #888280); }
+.ta-num { font-family: var(--ta-mono); font-size: 14px; font-variant-numeric: tabular-nums; }
+.ta-num--lg { font-size: 22px; font-family: var(--ta-serif); }
+.ta-right { text-align: right; }
+.ta-delta { display: inline-block; margin-left: 6px; font-family: var(--ta-mono); font-size: 11px; }
+.ta-delta.up { color: var(--ta-good); }
+.ta-delta.down { color: var(--ta-bad); }
+.ta-delta.flat { color: var(--ta-fg-muted); }
 
-.ta-loading {
-  padding: 16px; text-align: center;
-  font-family: var(--font-mono, monospace);
-  font-size: 11px; color: var(--fg-muted, #888280);
-  border-top: 1px solid var(--border-soft, #e6e2d6);
+.ta-spark { display: block; color: var(--ta-accent); }
+
+/* ---------- 2-up grid (team tab bottom panels) ---------- */
+.ta-row { display: grid; grid-template-columns: 1.6fr 1fr; gap: 18px; margin-top: 22px; }
+.ta-rule { height: 1px; background: var(--ta-border-soft); margin: 22px 0; border: 0; }
+
+/* ---------- chart helpers ---------- */
+.ta-chartwrap { padding: 22px; }
+.ta-chartwrap--small { padding: 18px 22px; }
+
+.ta-legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--ta-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  color: var(--ta-fg-muted);
+  flex-wrap: wrap;
+}
+.ta-legend i { display: inline-block; width: 10px; height: 10px; border-radius: 2px; vertical-align: -1px; margin-right: 4px; }
+
+.ta-chart-svg { display: block; width: 100%; }
+.ta-chart-axis { font-family: var(--ta-mono); font-size: 9.5px; fill: var(--ta-fg-muted); }
+.ta-chart-grid { stroke: var(--ta-border-soft); stroke-width: 1; }
+
+.ta-fact { font-family: var(--ta-serif); font-size: 14px; color: var(--ta-fg-soft); margin: 0; }
+.ta-fact strong { color: var(--ta-fg); }
+.ta-bullets { margin-top: 16px; display: flex; flex-direction: column; gap: 6px; font-family: var(--ta-mono); font-size: 11px; color: var(--ta-fg-soft); }
+.ta-bullets b { color: var(--ta-fg); font-weight: 500; }
+
+/* ---------- member profile ---------- */
+.ta-profile-grid { display: grid; grid-template-columns: 280px 1fr; gap: 20px; }
+.ta-profile-card {
+  padding: 22px;
+  border: 1px solid var(--ta-border-soft);
+  border-radius: 4px;
+  background: var(--ta-bg-elev);
+}
+.ta-profile-avatar {
+  width: 64px; height: 64px;
+  border-radius: 50%;
+  background: var(--ta-accent-soft);
+  color: var(--ta-accent);
+  display: inline-flex;
+  align-items: center; justify-content: center;
+  font-family: var(--ta-mono);
+  font-size: 18px;
+  font-weight: 600;
+  border: 1px solid var(--ta-border);
+}
+.ta-profile-name { font-family: var(--ta-serif); font-size: 24px; margin-top: 14px; line-height: 1.15; }
+.ta-profile-pillar { font-family: var(--ta-mono); font-size: 10.5px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--ta-fg-muted); margin-top: 4px; }
+.ta-profile-handles { margin-top: 12px; font-family: var(--ta-mono); font-size: 11px; color: var(--ta-fg-soft); }
+.ta-profile-handles div { padding: 1px 0; }
+
+.ta-kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1px;
+  background: var(--ta-border-soft);
+  margin: 18px -22px -22px;
+  border-top: 1px solid var(--ta-border-soft);
+}
+.ta-kpi { background: var(--ta-bg-elev); padding: 14px 18px; }
+.ta-kpi__lbl { font-family: var(--ta-mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ta-fg-muted); }
+.ta-kpi__val { font-family: var(--ta-serif); font-size: 26px; margin-top: 4px; }
+
+.ta-card {
+  background: var(--ta-bg-elev);
+  border: 1px solid var(--ta-border-soft);
+  border-radius: 4px;
+  padding: 18px 22px;
+}
+.ta-card + .ta-card { margin-top: 14px; }
+.ta-card__title {
+  font-family: var(--ta-serif);
+  font-size: 16px;
+  margin: 0 0 4px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.ta-card__sub {
+  font-family: var(--ta-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ta-fg-muted);
+  margin-bottom: 12px;
 }
 
-/* ---------- empty + banner ---------- */
+.ta-bar-row {
+  display: grid;
+  grid-template-columns: 110px 1fr 40px;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 0;
+}
+.ta-bar-label { font-family: var(--ta-mono); font-size: 11.5px; color: var(--ta-fg-soft); }
+.ta-bar-track { height: 12px; background: var(--ta-bg-soft); border-radius: 2px; overflow: hidden; }
+.ta-bar-fill { height: 100%; background: var(--ta-accent); }
+.ta-bar-num { text-align: right; font-family: var(--ta-mono); font-size: 11.5px; }
+
+.ta-sprint-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+  margin-top: 6px;
+}
+
+/* ---------- back link ---------- */
+.ta-backlink {
+  background: transparent;
+  border: 0;
+  font-family: var(--ta-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ta-fg-muted);
+  cursor: pointer;
+  padding: 0 0 14px;
+}
+.ta-backlink:hover { color: var(--ta-accent); }
+
+/* ---------- profile edit form ---------- */
+.ta-edit-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 14px;
+}
+.ta-field { display: flex; flex-direction: column; gap: 4px; }
+.ta-field-label {
+  font-family: var(--ta-mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ta-fg-muted);
+}
+.ta-field-help {
+  font-family: var(--ta-mono);
+  font-size: 10px;
+  color: var(--ta-fg-muted);
+  margin-top: 2px;
+  letter-spacing: 0.02em;
+}
+.ta-input {
+  font: inherit;
+  font-family: var(--ta-mono);
+  font-size: 13px;
+  padding: 7px 10px;
+  background: var(--ta-bg-elev);
+  border: 1px solid var(--ta-border);
+  border-radius: 3px;
+  color: var(--ta-fg);
+}
+.ta-input:focus { outline: 2px solid var(--ta-accent); outline-offset: -2px; }
+.ta-input--ro { background: var(--ta-bg-soft); color: var(--ta-fg-soft); }
+
+.ta-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  align-items: center;
+  margin-top: 12px;
+}
+.ta-btn {
+  font-family: var(--ta-mono);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  padding: 7px 14px;
+  border-radius: 3px;
+  cursor: pointer;
+  border: 1px solid var(--ta-border);
+  background: var(--ta-bg-elev);
+  color: var(--ta-fg-soft);
+}
+.ta-btn:hover:not(:disabled) { color: var(--ta-fg); }
+.ta-btn--primary {
+  background: var(--ta-accent);
+  border-color: var(--ta-accent);
+  color: #fff;
+}
+.ta-btn--primary:disabled { opacity: 0.5; cursor: not-allowed; }
+.ta-btn--primary:hover:not(:disabled) { background: #9b3933; color: #fff; }
+
+/* ---------- pivot table (Slice Explorer) ---------- */
+.ta-pivot-wrap { overflow-x: auto; }
+.ta-pivot { width: 100%; border-collapse: collapse; }
+.ta-pivot th, .ta-pivot td {
+  padding: 8px 10px;
+  font-family: var(--ta-mono);
+  font-size: 11.5px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  border-bottom: 1px solid var(--ta-border-soft);
+}
+.ta-pivot th {
+  background: #fbf9f4;
+  color: var(--ta-fg-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 10px;
+}
+.ta-pivot td:first-child, .ta-pivot th:first-child {
+  text-align: left;
+  font-family: var(--ta-serif);
+  font-size: 13.5px;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--ta-fg);
+  white-space: nowrap;
+}
+.ta-pivot td.heat {
+  position: relative;
+  color: var(--ta-fg);
+}
+.ta-pivot td.heat::before {
+  content: ""; position: absolute; inset: 2px 1px;
+  background: var(--ta-accent);
+  opacity: var(--h, 0);
+  border-radius: 2px;
+  z-index: 0;
+}
+.ta-pivot td.heat span { position: relative; z-index: 1; }
+.ta-pivot td.heat-zero { color: var(--ta-fg-muted); }
+
+.ta-pivot-foot {
+  padding: 14px 18px;
+  font-family: var(--ta-mono);
+  font-size: 10.5px;
+  color: var(--ta-fg-muted);
+  border-top: 1px solid var(--ta-border-soft);
+}
+
+/* ---------- empty / banner ---------- */
 .ta-empty {
   padding: 48px 32px;
   text-align: center;
-  background: var(--bg-elevated, #fff);
-  border: 1px dashed var(--border, #d8d2c4);
+  background: var(--ta-bg-elev);
+  border: 1px dashed var(--ta-border);
   border-radius: 4px;
 }
-.ta-empty h3 { font-family: var(--font-display, var(--font-serif, serif)); font-size: 18px; margin: 0 0 8px; }
-.ta-empty p { font-size: 13px; color: var(--fg-soft, #4a4a4a); max-width: 540px; margin: 4px auto; }
-.ta-empty a { color: var(--accent, #b8443c); }
+.ta-empty h3 { font-family: var(--ta-serif); font-size: 18px; margin: 0 0 8px; }
+.ta-empty p { font-size: 13px; color: var(--ta-fg-soft); max-width: 540px; margin: 4px auto; }
+.ta-empty a { color: var(--ta-accent); }
 
 .ta-banner {
   padding: 10px 14px;
@@ -146,210 +498,21 @@
   font-size: 13px;
   margin-bottom: 16px;
 }
-.ta-banner--bad { background: #fdf1f0; border: 1px solid #f3c8c4; color: #8d2a23; }
+.ta-banner--bad  { background: #fdf1f0; border: 1px solid #f3c8c4; color: #8d2a23; }
+.ta-banner--info { background: var(--ta-bg-soft); border: 1px dashed var(--ta-border); color: var(--ta-fg-soft); }
 
-/* ---------- footer ---------- */
-.ta-foot {
-  display: flex;
-  gap: 14px;
-  align-items: baseline;
-  padding-top: 16px;
-  margin-top: 24px;
-  border-top: 1px solid var(--border-soft, #e6e2d6);
-  font-size: 12px;
-  color: var(--fg-muted, #888280);
-}
-.ta-foot .mono { padding: 2px 8px; border: 1px solid var(--border, #d8d2c4); border-radius: 2px; font-size: 10.5px; letter-spacing: 0.16em; }
-
-/* ---------- clickable rows ---------- */
-.ta-row { cursor: pointer; transition: background 120ms ease; }
-.ta-row:hover { background: var(--bg-soft, #f7f4ec); }
-.ta-row.is-selected { background: var(--accent-soft, #efd9d4); }
-.ta-row.is-inactive { opacity: 0.55; }
-
-/* ---------- profile drawer ---------- */
-.ta-profile {
-  margin-top: 22px;
-  background: var(--bg-elevated, #fff);
-  border: 1px solid var(--border-soft, #e6e2d6);
-  border-radius: 4px;
-  padding: 22px 24px 24px;
-}
-.ta-profile-head {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-  flex-wrap: wrap;
-}
-.ta-profile-id {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  flex: 1;
-  min-width: 280px;
-}
-.ta-profile-avatar {
-  width: 52px; height: 52px;
-  border-radius: 50%;
-  background: var(--accent-soft, #efd9d4);
-  color: var(--accent, #b8443c);
-  display: inline-flex;
-  align-items: center; justify-content: center;
-  font-family: var(--font-mono, monospace);
-  font-size: 16px;
-  font-weight: 600;
-  border: 1px solid var(--border, #d8d2c4);
-}
-.ta-profile-name {
-  font-family: var(--font-display, var(--font-serif, serif));
-  font-size: 22px;
-  margin: 0;
-  line-height: 1.2;
-}
-.ta-profile-handle {
-  font-family: var(--font-mono, monospace);
+.ta-loading {
+  padding: 16px;
+  text-align: center;
+  font-family: var(--ta-mono);
   font-size: 11px;
-  color: var(--fg-muted, #888280);
-  margin-top: 2px;
-  letter-spacing: 0.04em;
-}
-.ta-profile-close {
-  background: none;
-  border: 1px solid var(--border, #d8d2c4);
-  color: var(--fg-soft, #4a4a4a);
-  font-family: var(--font-mono, monospace);
-  font-size: 10.5px;
-  letter-spacing: 0.16em;
-  padding: 4px 12px;
-  border-radius: 999px;
-  cursor: pointer;
-  text-transform: uppercase;
-}
-.ta-profile-close:hover { color: var(--accent, #b8443c); border-color: var(--accent, #b8443c); }
-
-.ta-profile-kpis {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 12px;
-  margin: 22px 0 18px;
-}
-.ta-kpi {
-  border: 1px solid var(--border-soft, #e6e2d6);
-  background: var(--bg-soft, #f7f4ec);
-  padding: 12px 14px;
-  border-radius: 4px;
-}
-.ta-kpi-label {
-  font-family: var(--font-mono, monospace);
-  font-size: 10px;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--fg-muted, #888280);
-}
-.ta-kpi-value {
-  font-family: var(--font-display, var(--font-serif, serif));
-  font-size: 28px;
-  margin-top: 4px;
-  line-height: 1;
-  color: var(--fg, #1a1a1a);
+  color: var(--ta-fg-muted);
+  border-top: 1px solid var(--ta-border-soft);
 }
 
-.ta-profile-form {
-  border-top: 1px solid var(--border-soft, #e6e2d6);
-  padding-top: 18px;
-  display: grid;
-  gap: 14px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-.ta-field { display: flex; flex-direction: column; gap: 4px; }
-.ta-field-label {
-  font-family: var(--font-mono, monospace);
-  font-size: 10px;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--fg-muted, #888280);
-}
-.ta-field-help {
-  font-family: var(--font-mono, monospace);
-  font-size: 10px;
-  color: var(--fg-muted, #888280);
-  margin-top: 2px;
-  letter-spacing: 0.02em;
-}
-.ta-input {
-  font: inherit;
-  font-family: var(--font-mono, monospace);
-  font-size: 13px;
-  padding: 7px 10px;
-  background: var(--bg-elevated, #fff);
-  border: 1px solid var(--border, #d8d2c4);
-  border-radius: 3px;
-  color: var(--fg, #1a1a1a);
-}
-.ta-input:focus { outline: 2px solid var(--accent, #b8443c); outline-offset: -2px; }
-.ta-input--ro { background: var(--bg-soft, #f7f4ec); color: var(--fg-soft, #4a4a4a); }
-
-.ta-form-actions {
-  grid-column: 1 / -1;
-  display: flex;
-  justify-content: flex-end;
-  gap: 10px;
-  align-items: center;
-  margin-top: 4px;
-}
-.ta-btn {
-  font-family: var(--font-mono, monospace);
-  font-size: 11px;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  padding: 7px 14px;
-  border-radius: 3px;
-  cursor: pointer;
-  border: 1px solid var(--border, #d8d2c4);
-  background: var(--bg-elevated, #fff);
-  color: var(--fg-soft, #4a4a4a);
-}
-.ta-btn:hover { color: var(--fg, #1a1a1a); }
-.ta-btn--primary {
-  background: var(--accent, #b8443c);
-  border-color: var(--accent, #b8443c);
-  color: #fff;
-}
-.ta-btn--primary:disabled { opacity: 0.5; cursor: not-allowed; }
-.ta-btn--primary:hover:not(:disabled) { background: #9b3933; color: #fff; }
-
-.ta-trend {
-  margin-top: 22px;
-  padding-top: 18px;
-  border-top: 1px solid var(--border-soft, #e6e2d6);
-}
-.ta-trend-title {
-  font-family: var(--font-mono, monospace);
-  font-size: 10px;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--fg-muted, #888280);
-  margin: 0 0 10px;
-}
-.ta-trend-svg { display: block; width: 100%; }
-.ta-trend-axis {
-  font-family: var(--font-mono, monospace);
-  font-size: 9.5px;
-  fill: var(--fg-muted, #888280);
-}
-.ta-trend-legend {
-  display: flex;
-  gap: 14px;
-  margin-top: 8px;
-  font-family: var(--font-mono, monospace);
-  font-size: 10px;
-  color: var(--fg-muted, #888280);
-}
-.ta-trend-legend i {
-  display: inline-block;
-  width: 10px; height: 10px;
-  margin-right: 4px;
-  vertical-align: -1px;
-  border-radius: 2px;
+/* ---------- responsive ---------- */
+@media (max-width: 1100px) {
+  .ta-row { grid-template-columns: 1fr; }
+  .ta-profile-grid { grid-template-columns: 1fr; }
+  .ta-sprint-grid { grid-template-columns: repeat(2, 1fr); }
 }

--- a/roadmap-planner/frontend/src/components/TeamAnalytics.css
+++ b/roadmap-planner/frontend/src/components/TeamAnalytics.css
@@ -191,6 +191,24 @@
   border-color: var(--fg);
 }
 
+.ta-pillar-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  max-width: 240px;
+}
+.ta-pillar-tag {
+  display: inline-block;
+  padding: 1px 7px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-pill, 999px);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-subtle);
+  background: var(--bg-sunken);
+  white-space: nowrap;
+}
+
 .ta-seg {
   display: inline-flex;
   border: 1px solid var(--border);

--- a/roadmap-planner/frontend/src/components/TeamAnalytics.jsx
+++ b/roadmap-planner/frontend/src/components/TeamAnalytics.jsx
@@ -1,33 +1,46 @@
 /*
- * Team Analytics — production view.
+ * Team Analytics — production view, faithful to docs/team-analytics/prototype.html.
  *
- * Layout:
- *   - team-overview table (clickable rows)
- *   - inline Member Profile drawer with:
- *       · identity card + editable github_login (PATCH /members/:id)
- *       · KPI tiles
- *       · 3-line weekly trend (Jira / PRs / Reviews)
- *   - last-sync footer per source
+ * Three tabs:
+ *   1. Team overview   — sortable table with deltas, pillar filter pills,
+ *                        throughput-by-pillar stack chart, review network panel.
+ *   2. Member profile  — sidebar identity + KPI grid · multi-line weekly chart
+ *                        · components-touched bars · this-sprint stats. Has
+ *                        an inline edit form for github_login + pillar.
+ *   3. Slice explorer  — pivot of (member|pillar) × (week|quarter)
+ *                        on (PRs merged|Jira done|Story pts) with heat tint.
  *
- * The Jira → GitHub identity link is intentionally manual: the user
- * fills in `github_login` here, the backend triggers an aggregator
- * rebuild, and PR / review counts repopulate on the next read. We do
- * not auto-match by email — too many false positives on profiles that
- * don't expose email publicly.
- *
- * Inactive Jira users (deactivated accounts) are filtered server-side
- * by default. Pass ?include_inactive=1 to the URL to see them.
+ * Tab + selected member are reflected into ?tab=…&member=… so the view
+ * is deep-linkable and the browser's back button works as expected.
  */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
 import { contributionsAPI, handleAPIError } from '../services/api';
 import './TeamAnalytics.css';
 
-const formatHours = (h) => (h == null ? '—' : `${h.toFixed(1)}h`);
+/* -------------------------------------------------------------------- */
+/*  Generic helpers                                                      */
+/* -------------------------------------------------------------------- */
+
+const PILLAR_COLORS = {
+  Unassigned: '#a39a8a',
+};
+const SERIES_PALETTE = ['#b8443c', '#2c5d75', '#b87a1a', '#3a6d4b', '#7a4f9c', '#9c4f4f', '#4f7f9c'];
+
+const formatHours = (h) => (h == null ? '—' : `${(+h).toFixed(1)}h`);
+const formatPct = (p) => (p == null || isNaN(p) ? '—' : `${Math.round(p)}%`);
+const formatPctOne = (p) => (p == null || isNaN(p) ? '—' : `${(+p).toFixed(1)}%`);
 const formatDate = (s) => {
   if (!s) return '—';
   try { return new Date(s).toISOString().slice(0, 16).replace('T', ' '); }
   catch { return s; }
+};
+
+const pick = (obj, ...keys) => {
+  for (const k of keys) {
+    if (obj && obj[k] !== undefined && obj[k] !== null && obj[k] !== '') return obj[k];
+  }
+  return '';
 };
 
 const initialsOf = (name) =>
@@ -39,28 +52,37 @@ const initialsOf = (name) =>
     .join('')
     .toUpperCase() || '?';
 
-// pick walks an object for the first non-empty value across snake_case
-// + PascalCase aliases. Defensive against API rollout windows.
-const pick = (obj, ...keys) => {
-  for (const k of keys) {
-    if (obj && obj[k] !== undefined && obj[k] !== null && obj[k] !== '') return obj[k];
-  }
-  return '';
+const colorForPillar = (p, fallbackIdx = 0) => {
+  if (!p) return PILLAR_COLORS.Unassigned;
+  if (PILLAR_COLORS[p]) return PILLAR_COLORS[p];
+  let h = 0;
+  for (let i = 0; i < p.length; i++) h = (h * 31 + p.charCodeAt(i)) >>> 0;
+  return SERIES_PALETTE[(h + fallbackIdx) % SERIES_PALETTE.length];
 };
 
-// readQueryMember is a read-only sniff of ?member=<id> from the URL so
-// teammates can deep-link to a profile. Updates use replaceState
-// instead of pushState to avoid pollluting browser history with every
-// table click.
-const readQueryMember = () => {
-  if (typeof window === 'undefined') return '';
-  try { return new URLSearchParams(window.location.search).get('member') || ''; }
-  catch { return ''; }
+/* -------------------------------------------------------------------- */
+/*  URL state — ?tab=&member=                                            */
+/* -------------------------------------------------------------------- */
+
+const VALID_TABS = new Set(['team', 'member', 'slice']);
+const readURLState = () => {
+  if (typeof window === 'undefined') return { tab: 'team', id: '' };
+  try {
+    const p = new URLSearchParams(window.location.search);
+    let tab = p.get('tab') || '';
+    const id = p.get('member') || p.get('id') || '';
+    if (!VALID_TABS.has(tab)) tab = id ? 'member' : 'team';
+    return { tab, id };
+  } catch {
+    return { tab: 'team', id: '' };
+  }
 };
-const writeQueryMember = (id) => {
+const writeURLState = ({ tab, id }) => {
   if (typeof window === 'undefined') return;
   try {
     const url = new URL(window.location.href);
+    if (tab && tab !== 'team') url.searchParams.set('tab', tab);
+    else url.searchParams.delete('tab');
     if (id) url.searchParams.set('member', id);
     else url.searchParams.delete('member');
     window.history.replaceState({}, '', url.toString());
@@ -69,91 +91,227 @@ const writeQueryMember = (id) => {
   }
 };
 
-// Tiny inline sparkline. Used in the table row.
-function Spark({ values, color = 'currentColor', width = 96, height = 22 }) {
+/* -------------------------------------------------------------------- */
+/*  Delta indicator (last-4 vs prior-4 weeks)                            */
+/* -------------------------------------------------------------------- */
+
+const computeDelta = (series, key) => {
+  if (!series || series.length < 8) return { kind: 'flat', pct: 0, ok: false };
+  const recent = series.slice(-4).reduce((a, s) => a + (s[key] || 0), 0);
+  const prior  = series.slice(-8, -4).reduce((a, s) => a + (s[key] || 0), 0);
+  if (prior === 0) {
+    if (recent > 0) return { kind: 'up', pct: 100, ok: true, novel: true };
+    return { kind: 'flat', pct: 0, ok: false };
+  }
+  const pct = Math.round(((recent - prior) / prior) * 100);
+  if (Math.abs(pct) < 5) return { kind: 'flat', pct: Math.abs(pct), ok: true };
+  return { kind: pct > 0 ? 'up' : 'down', pct: Math.abs(pct), ok: true };
+};
+
+function DeltaPill({ d }) {
+  if (!d || !d.ok) return <span className="ta-delta flat">·</span>;
+  if (d.kind === 'flat') return <span className="ta-delta flat">±{d.pct}%</span>;
+  return <span className={`ta-delta ${d.kind}`}>{d.kind === 'up' ? '▲' : '▼'} {d.pct}%</span>;
+}
+
+/* -------------------------------------------------------------------- */
+/*  Sparkline (table cell)                                               */
+/* -------------------------------------------------------------------- */
+
+function Spark({ values, color = 'currentColor', width = 110, height = 28 }) {
   if (!values || values.length === 0) {
-    return <span className="ta-spark ta-spark--empty">—</span>;
+    return <span className="ta-meta">—</span>;
   }
   const max = Math.max(1, ...values);
   const step = (width - 4) / Math.max(1, values.length - 1);
-  const pts = values.map((v, i) => `${2 + i * step},${height - 2 - (v / max) * (height - 4)}`).join(' ');
+  const pts = values.map((v, i) => `${2 + i * step},${height - 2 - (v / max) * (height - 4)}`);
+  const last = pts[pts.length - 1].split(',');
   return (
     <svg className="ta-spark" width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
-      <polyline fill="none" stroke={color} strokeWidth="1.4" points={pts} />
+      <polyline fill="none" stroke={color} strokeWidth="1.4" points={pts.join(' ')} />
+      <circle cx={last[0]} cy={last[1]} r="2.2" fill={color} />
     </svg>
   );
 }
 
-// Multi-series line chart used in the profile trend section. We render
-// hand-written SVG instead of pulling Recharts here because we want
-// total control over the visual language (mono labels, restrained
-// palette) and the data shape is tiny.
-function TrendChart({ series, height = 160 }) {
-  const padding = { top: 8, right: 8, bottom: 22, left: 28 };
-  const width = 720; // viewBox width; CSS scales it.
-  const inner = { w: width - padding.left - padding.right, h: height - padding.top - padding.bottom };
-  const lengths = series.map((s) => s.values.length);
-  const n = Math.max(0, ...lengths);
-  if (n === 0) {
-    return <div className="ta-trend-axis" style={{ padding: '12px 0' }}>No activity in window.</div>;
-  }
-  const max = Math.max(1, ...series.flatMap((s) => s.values));
-  const step = inner.w / Math.max(1, n - 1);
-  const yOf = (v) => padding.top + inner.h - (v / max) * inner.h;
-  const xOf = (i) => padding.left + i * step;
+/* -------------------------------------------------------------------- */
+/*  Pillar throughput stack chart (Team tab)                             */
+/* -------------------------------------------------------------------- */
 
-  // Y ticks: 0, max/2, max
-  const yTicks = [0, max / 2, max];
+function PillarStack({ buckets }) {
+  if (!buckets || buckets.length === 0) {
+    return <p className="ta-meta">No throughput data in window.</p>;
+  }
+  const byWeek = new Map();
+  const pillars = new Set();
+  buckets.forEach((b) => {
+    pillars.add(b.pillar);
+    const k = b.week_start;
+    if (!byWeek.has(k)) byWeek.set(k, {});
+    byWeek.get(k)[b.pillar] = b.prs_merged || 0;
+  });
+  const weekKeys = [...byWeek.keys()].sort();
+  const pillarList = [...pillars].sort();
+  const stack = weekKeys.map((wk) => {
+    const cell = byWeek.get(wk);
+    return { week: wk, ...Object.fromEntries(pillarList.map((p) => [p, cell[p] || 0])) };
+  });
+  const max = Math.max(1, ...stack.map((s) => pillarList.reduce((a, p) => a + s[p], 0)));
+
+  const W = 600, H = 240, pad = { l: 36, r: 12, t: 14, b: 36 };
+  const xStep = (W - pad.l - pad.r) / Math.max(1, stack.length);
+
+  const colors = Object.fromEntries(pillarList.map((p, i) => [p, colorForPillar(p, i)]));
 
   return (
     <>
-      <svg className="ta-trend-svg" viewBox={`0 0 ${width} ${height}`} preserveAspectRatio="none">
-        {/* axis lines */}
-        <line x1={padding.left} y1={padding.top} x2={padding.left} y2={padding.top + inner.h}
-              stroke="var(--border, #d8d2c4)" strokeWidth="1" />
-        <line x1={padding.left} y1={padding.top + inner.h} x2={padding.left + inner.w} y2={padding.top + inner.h}
-              stroke="var(--border, #d8d2c4)" strokeWidth="1" />
-        {/* y-tick gridlines + labels */}
-        {yTicks.map((t, i) => (
-          <g key={i}>
-            <line x1={padding.left} y1={yOf(t)} x2={padding.left + inner.w} y2={yOf(t)}
-                  stroke="var(--border-soft, #e6e2d6)" strokeWidth="1" strokeDasharray="2 3" />
-            <text className="ta-trend-axis" x={padding.left - 4} y={yOf(t) + 3} textAnchor="end">
-              {Math.round(t)}
-            </text>
-          </g>
-        ))}
-        {/* x-axis week labels (every other to avoid crowding) */}
-        {(series[0]?.labels || []).map((lab, i) => {
-          if (i % 2 !== 0 && i !== n - 1) return null;
+      <svg className="ta-chart-svg" viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none">
+        {[0, 1, 2, 3, 4].map((g) => {
+          const y = pad.t + (H - pad.t - pad.b) * (g / 4);
+          const v = Math.round(max * (1 - g / 4));
           return (
-            <text key={i} className="ta-trend-axis"
-                  x={xOf(i)} y={padding.top + inner.h + 14} textAnchor="middle">
-              {lab}
-            </text>
-          );
-        })}
-        {/* series */}
-        {series.map((s) => {
-          const pts = s.values.map((v, i) => `${xOf(i)},${yOf(v)}`).join(' ');
-          return (
-            <g key={s.label}>
-              <polyline fill="none" stroke={s.color} strokeWidth="1.6" points={pts} />
-              {s.values.map((v, i) => (
-                <circle key={i} cx={xOf(i)} cy={yOf(v)} r="2.5" fill={s.color} />
-              ))}
+            <g key={g}>
+              <line className="ta-chart-grid" x1={pad.l} x2={W - pad.r} y1={y} y2={y} />
+              <text className="ta-chart-axis" x={pad.l - 6} y={y + 3} textAnchor="end">{v}</text>
             </g>
           );
         })}
+        {stack.map((s, i) => {
+          let yCur = H - pad.b;
+          return (
+            <g key={s.week}>
+              {pillarList.map((p) => {
+                const h = (s[p] / max) * (H - pad.t - pad.b);
+                yCur -= h;
+                return (
+                  <rect key={p}
+                    x={pad.l + i * xStep + 2}
+                    y={yCur}
+                    width={Math.max(1, xStep - 4)}
+                    height={Math.max(0, h)}
+                    fill={colors[p]}
+                    opacity="0.85" />
+                );
+              })}
+            </g>
+          );
+        })}
+        {stack.map((s, i) => {
+          if (i % 2 !== 0 && i !== stack.length - 1) return null;
+          const lab = (s.week || '').slice(5, 10);
+          return (
+            <text key={i} className="ta-chart-axis"
+                  x={pad.l + i * xStep + xStep / 2}
+                  y={H - pad.b + 14} textAnchor="middle">{lab}</text>
+          );
+        })}
       </svg>
-      <div className="ta-trend-legend">
-        {series.map((s) => (
-          <span key={s.label}><i style={{ background: s.color }} />{s.label}</span>
+      <div className="ta-legend" style={{ marginTop: 10 }}>
+        {pillarList.map((p) => (
+          <span key={p}><i style={{ background: colors[p] }} />{p}</span>
         ))}
       </div>
     </>
   );
 }
+
+/* -------------------------------------------------------------------- */
+/*  Network density panel (Team tab)                                     */
+/* -------------------------------------------------------------------- */
+
+function NetworkPanel({ network }) {
+  if (!network || !network.prs_considered) {
+    return (
+      <div className="ta-chartwrap--small">
+        <p className="ta-fact">
+          Review-network metrics need at least one PR + review in the window.
+          Once GitHub sync has populated history (and members have <code>github_login</code>
+          set on their profile), this panel surfaces orphan rate, first-review p50/p90,
+          and cross-pillar review percentage.
+        </p>
+      </div>
+    );
+  }
+  const under24 = formatPct(network.first_review_under_24h_pct);
+  const cross   = formatPct(network.cross_pillar_review_pct);
+  return (
+    <div className="ta-chartwrap--small">
+      <p className="ta-fact">
+        Last 12 weeks: <strong>{under24}</strong> of PRs received their first review within 24 hours.
+        Cross-pillar review participation is <strong>{cross}</strong> — that's a
+        leading indicator of knowledge sharing, and you can slice it on the Slice tab.
+      </p>
+      <div className="ta-bullets">
+        <div>→ p50 first-review latency · <b>{formatHours(network.first_review_p50_hours)}</b></div>
+        <div>→ p90 first-review latency · <b>{formatHours(network.first_review_p90_hours)}</b></div>
+        <div>→ orphan PRs (no review)   · <b>{formatPctOne(network.orphan_pct)}</b> of {network.prs_considered}</div>
+      </div>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------- */
+/*  Multi-line weekly trend (Member profile)                             */
+/* -------------------------------------------------------------------- */
+
+function TrendChart({ weeks }) {
+  if (!weeks || weeks.length === 0) {
+    return <p className="ta-meta">No activity in window.</p>;
+  }
+  const W = 720, H = 220, pad = { l: 40, r: 12, t: 14, b: 30 };
+  const allMax = Math.max(1, ...weeks.flatMap((w) => [w.jira_done || 0, w.prs_merged || 0, w.reviews || 0]));
+  const xStep = (W - pad.l - pad.r) / Math.max(1, weeks.length - 1);
+  const yOf = (v) => H - pad.b - (v / allMax) * (H - pad.t - pad.b);
+  const xOf = (i) => pad.l + i * xStep;
+
+  const lines = [
+    { key: 'jira_done', color: '#2c5d75' },
+    { key: 'reviews',   color: '#b87a1a' },
+    { key: 'prs_merged',color: 'var(--ta-accent, #b8443c)' },
+  ];
+
+  return (
+    <>
+      <svg className="ta-chart-svg" viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none">
+        {[0, 1, 2, 3, 4].map((g) => {
+          const y = pad.t + (H - pad.t - pad.b) * (g / 4);
+          const v = Math.round(allMax * (1 - g / 4));
+          return (
+            <g key={g}>
+              <line className="ta-chart-grid" x1={pad.l} x2={W - pad.r} y1={y} y2={y} />
+              <text className="ta-chart-axis" x={pad.l - 6} y={y + 3} textAnchor="end">{v}</text>
+            </g>
+          );
+        })}
+        {weeks.map((w, i) => (
+          <text key={i} className="ta-chart-axis"
+                x={xOf(i)} y={H - 10} textAnchor="middle">w{i + 1}</text>
+        ))}
+        {lines.map((ln) => {
+          const pts = weeks.map((w, i) => `${xOf(i)},${yOf(w[ln.key] || 0)}`);
+          return (
+            <g key={ln.key}>
+              <polyline fill="none" stroke={ln.color} strokeWidth="1.7" points={pts.join(' ')} />
+              {pts.map((p, i) => {
+                const [cx, cy] = p.split(',');
+                return <circle key={i} cx={cx} cy={cy} r="2.5" fill={ln.color} />;
+              })}
+            </g>
+          );
+        })}
+      </svg>
+      <div className="ta-legend" style={{ marginTop: 6 }}>
+        <span><i style={{ background: 'var(--ta-accent, #b8443c)' }} />PRs merged</span>
+        <span><i style={{ background: '#2c5d75' }} />Jira done</span>
+        <span><i style={{ background: '#b87a1a' }} />Reviews</span>
+      </div>
+    </>
+  );
+}
+
+/* -------------------------------------------------------------------- */
+/*  Status badge (last-sync indicator)                                   */
+/* -------------------------------------------------------------------- */
 
 function StatusBadge({ source, info }) {
   let label, kind;
@@ -170,206 +328,57 @@ function StatusBadge({ source, info }) {
   return <span className={`ta-badge ta-badge--${kind}`}>{label}</span>;
 }
 
-const COLUMNS = [
-  { key: 'name',      label: 'Member',      align: 'left',  sortable: true  },
-  { key: 'jira',      label: 'Jira done',   align: 'right', sortable: true  },
-  { key: 'points',    label: 'Story pts',   align: 'right', sortable: true  },
-  { key: 'prs',       label: 'PRs merged',  align: 'right', sortable: true  },
-  { key: 'reviews',   label: 'Reviews',     align: 'right', sortable: true  },
-  { key: 'latency',   label: 'Review p50',  align: 'right', sortable: true  },
-  { key: 'spark',     label: 'PRs / wk',    align: 'left',  sortable: false },
+/* -------------------------------------------------------------------- */
+/*  Top-level component                                                  */
+/* -------------------------------------------------------------------- */
+
+const TABLE_COLS = [
+  { key: 'name',    label: 'Member',     align: 'left',  sortable: true },
+  { key: 'pillar',  label: 'Pillar',     align: 'left',  sortable: true },
+  { key: 'jira',    label: 'Jira done',  align: 'right', sortable: true, withDelta: 'jira_done' },
+  { key: 'points',  label: 'Story pts',  align: 'right', sortable: true },
+  { key: 'prs',     label: 'PRs merged', align: 'right', sortable: true, withDelta: 'prs_merged' },
+  { key: 'reviews', label: 'Reviews',    align: 'right', sortable: true, withDelta: 'reviews' },
+  { key: 'latency', label: 'Review p50', align: 'right', sortable: true },
+  { key: 'spark',   label: 'PRs / wk',   align: 'left',  sortable: false },
 ];
 
-// --------------------------------------------------------------------
-// MemberProfile — drawer that opens when a row is clicked. It owns its
-// own data fetch (detail endpoint) and the PATCH form. The parent
-// passes the row data only as a "first paint" placeholder so the panel
-// is never empty while loading.
-// --------------------------------------------------------------------
-function MemberProfile({ row, onClose, onSaved }) {
-  const [data, setData] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [github, setGithub] = useState('');
-  const [pillar, setPillar] = useState('');
-
-  // Reset state any time the selected member changes.
-  useEffect(() => {
-    let cancelled = false;
-    const load = async () => {
-      setLoading(true);
-      try {
-        const detail = await contributionsAPI.member(row.id);
-        if (cancelled) return;
-        setData(detail);
-        setGithub(pick(detail.info, 'github_login', 'GitHubLogin') || row.github || '');
-        setPillar(pick(detail.info, 'pillar_id', 'PillarID') || row.pillar || '');
-      } catch (e) {
-        if (cancelled) return;
-        const err = handleAPIError(e);
-        toast.error(`Profile load: ${err.message}`);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    };
-    load();
-    return () => { cancelled = true; };
-  }, [row.id, row.github, row.pillar]);
-
-  const info = data?.info || {};
-  const totals = {
-    jira: data?.jira_issues_done ?? row.jira ?? 0,
-    points: data?.jira_points_done ?? row.points ?? 0,
-    prs: data?.prs_merged ?? row.prs ?? 0,
-    reviews: data?.prs_reviewed ?? row.reviews ?? 0,
-    latency: data?.review_latency_p50_hours ?? row.latency,
-  };
-
-  const weeks = data?.week_totals || [];
-  const labels = weeks.map((w) => {
-    if (!w.week_start) return '';
-    try { return new Date(w.week_start).toISOString().slice(5, 10); }
-    catch { return ''; }
-  });
-  const series = [
-    { label: 'Jira done',   color: '#b8443c', values: weeks.map((w) => w.jira_done || 0),  labels },
-    { label: 'PRs merged',  color: '#4a7d9c', values: weeks.map((w) => w.prs_merged || 0), labels },
-    { label: 'Reviews',     color: '#6cb073', values: weeks.map((w) => w.reviews || 0),    labels },
-  ];
-
-  const dirty =
-    String(github || '').toLowerCase() !== String(pick(info, 'github_login', 'GitHubLogin') || '').toLowerCase()
-    || String(pillar || '') !== String(pick(info, 'pillar_id', 'PillarID') || '');
-
-  const onSave = useCallback(async () => {
-    setSaving(true);
-    try {
-      const payload = {
-        github_login: (github || '').trim(),
-        pillar_id: (pillar || '').trim(),
-      };
-      const updated = await contributionsAPI.updateMember(row.id, payload);
-      toast.success('Saved · rebuilding rollups in background');
-      // Refresh the local detail with the updated identity, but keep
-      // the previously fetched week_totals (the rebuild is async — the
-      // numbers will update on the next reload).
-      setData((prev) => ({ ...(prev || {}), info: updated }));
-      onSaved?.(updated);
-    } catch (e) {
-      const err = handleAPIError(e);
-      toast.error(`Save failed: ${err.message}`);
-    } finally {
-      setSaving(false);
-    }
-  }, [github, pillar, row.id, onSaved]);
-
-  return (
-    <section className="ta-profile" aria-label="Member profile">
-      <div className="ta-profile-head">
-        <div className="ta-profile-id">
-          <span className="ta-profile-avatar">{initialsOf(pick(info, 'display_name', 'DisplayName') || row.name)}</span>
-          <div>
-            <h2 className="ta-profile-name">{pick(info, 'display_name', 'DisplayName') || row.name || row.id}</h2>
-            <div className="ta-profile-handle">
-              {pick(info, 'email', 'Email') || row.id}
-              {pick(info, 'github_login', 'GitHubLogin') && (
-                <> · <span style={{ color: 'var(--accent, #b8443c)' }}>@{pick(info, 'github_login', 'GitHubLogin')}</span></>
-              )}
-            </div>
-          </div>
-        </div>
-        <button className="ta-profile-close" onClick={onClose} aria-label="Close profile">Close ✕</button>
-      </div>
-
-      <div className="ta-profile-kpis">
-        <div className="ta-kpi"><div className="ta-kpi-label">Jira done</div><div className="ta-kpi-value">{totals.jira}</div></div>
-        <div className="ta-kpi"><div className="ta-kpi-label">Story pts</div><div className="ta-kpi-value">{Number.isFinite(totals.points) ? totals.points.toFixed(1) : '0.0'}</div></div>
-        <div className="ta-kpi"><div className="ta-kpi-label">PRs merged</div><div className="ta-kpi-value">{totals.prs}</div></div>
-        <div className="ta-kpi"><div className="ta-kpi-label">Reviews</div><div className="ta-kpi-value">{totals.reviews}</div></div>
-        <div className="ta-kpi"><div className="ta-kpi-label">Review p50</div><div className="ta-kpi-value">{formatHours(totals.latency)}</div></div>
-      </div>
-
-      <form className="ta-profile-form" onSubmit={(e) => { e.preventDefault(); onSave(); }}>
-        <label className="ta-field">
-          <span className="ta-field-label">Member ID</span>
-          <input className="ta-input ta-input--ro" value={row.id} readOnly />
-          <span className="ta-field-help">Stable internal slug — derived from email at first sync.</span>
-        </label>
-        <label className="ta-field">
-          <span className="ta-field-label">Email (Jira)</span>
-          <input className="ta-input ta-input--ro" value={pick(info, 'email', 'Email') || ''} readOnly />
-        </label>
-        <label className="ta-field">
-          <span className="ta-field-label">Jira Account ID</span>
-          <input className="ta-input ta-input--ro" value={pick(info, 'jira_account_id', 'JiraAccountID') || ''} readOnly />
-        </label>
-        <label className="ta-field">
-          <span className="ta-field-label">GitHub login *</span>
-          <input
-            className="ta-input"
-            value={github}
-            onChange={(e) => setGithub(e.target.value)}
-            placeholder="alicetan"
-            autoComplete="off"
-            spellCheck={false}
-          />
-          <span className="ta-field-help">Maps PRs / reviews to this person. Empty = no GitHub link.</span>
-        </label>
-        <label className="ta-field">
-          <span className="ta-field-label">Pillar</span>
-          <input
-            className="ta-input"
-            value={pillar}
-            onChange={(e) => setPillar(e.target.value)}
-            placeholder="essentials"
-          />
-        </label>
-        <div className="ta-form-actions">
-          {loading && <span className="ta-field-help">Loading…</span>}
-          {saving && <span className="ta-field-help">Saving…</span>}
-          <button type="button" className="ta-btn" onClick={onClose}>Cancel</button>
-          <button type="submit" className="ta-btn ta-btn--primary" disabled={!dirty || saving || loading}>
-            Save
-          </button>
-        </div>
-      </form>
-
-      <div className="ta-trend">
-        <h3 className="ta-trend-title">Weekly activity · last {weeks.length || 12} weeks</h3>
-        <TrendChart series={series} />
-      </div>
-    </section>
-  );
-}
-
-// --------------------------------------------------------------------
-// TeamAnalytics — root component
-// --------------------------------------------------------------------
 export default function TeamAnalytics() {
+  const initial = readURLState();
+  const [tab, setTab] = useState(initial.tab);
+  const [selectedID, setSelectedID] = useState(initial.id);
+
   const [members, setMembers] = useState([]);
   const [team, setTeam] = useState([]);
   const [status, setStatus] = useState(null);
+  const [network, setNetwork] = useState(null);
+  const [pillars, setPillars] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [reloadTick, setReloadTick] = useState(0);
+  const [pillarFilter, setPillarFilter] = useState('all');
+
   const [sortKey, setSortKey] = useState('name');
   const [sortDir, setSortDir] = useState('asc');
-  const [selectedID, setSelectedID] = useState(readQueryMember());
-  const [reloadTick, setReloadTick] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
     const load = async () => {
       try {
         setLoading(true);
-        const [membersResp, teamResp, statusResp] = await Promise.all([
+        const [membersResp, teamResp, statusResp, netResp, pillResp] = await Promise.all([
           contributionsAPI.listMembers().catch(() => ({ members: [] })),
           contributionsAPI.team().catch(() => ({ members: [] })),
           contributionsAPI.status().catch(() => null),
+          contributionsAPI.network().catch(() => null),
+          contributionsAPI.pillars().catch(() => ({ buckets: [] })),
         ]);
         if (cancelled) return;
         setMembers(membersResp.members || []);
         setTeam(teamResp.members || []);
         setStatus(statusResp);
+        setNetwork(netResp);
+        setPillars(pillResp.buckets || []);
       } catch (e) {
         if (cancelled) return;
         const err = handleAPIError(e);
@@ -388,40 +397,55 @@ export default function TeamAnalytics() {
     const merged = (members || []).map((m) => {
       const id = pick(m, 'id', 'ID');
       const t = byID.get(id) || {};
-      const sparkValues = (t.week_totals || []).map((w) => w.prs_merged || 0);
-      const display = pick(m, 'display_name', 'DisplayName');
+      const week_totals = t.week_totals || [];
       return {
         id,
-        name: display || id || 'unknown',
+        name: pick(m, 'display_name', 'DisplayName') || id || 'unknown',
         github: pick(m, 'github_login', 'GitHubLogin'),
+        email:  pick(m, 'email', 'Email'),
+        jira_account_id: pick(m, 'jira_account_id', 'JiraAccountID'),
         pillar: pick(m, 'pillar_id', 'PillarID'),
-        active: pick(m, 'active', 'Active') !== false, // default true
-        jira: t.jira_issues_done || 0,
-        points: t.jira_points_done || 0,
-        prs: t.prs_merged || 0,
+        active: pick(m, 'active', 'Active') !== false,
+        jira:    t.jira_issues_done || 0,
+        points:  t.jira_points_done || 0,
+        prs:     t.prs_merged || 0,
         reviews: t.prs_reviewed || 0,
         latency: t.review_latency_p50_hours,
-        spark: sparkValues,
+        week_totals,
       };
     });
     (team || []).forEach((t) => {
-      if (!members.find((m) => (pick(m, 'id', 'ID') === t.member_id))) {
+      if (!members.find((m) => pick(m, 'id', 'ID') === t.member_id)) {
         merged.push({
-          id: t.member_id, name: t.member_id, github: '', pillar: '', active: true,
-          jira: t.jira_issues_done || 0,
-          points: t.jira_points_done || 0,
-          prs: t.prs_merged || 0,
+          id: t.member_id, name: t.member_id,
+          github: '', email: '', jira_account_id: '',
+          pillar: '', active: true,
+          jira:    t.jira_issues_done || 0,
+          points:  t.jira_points_done || 0,
+          prs:     t.prs_merged || 0,
           reviews: t.prs_reviewed || 0,
           latency: t.review_latency_p50_hours,
-          spark: (t.week_totals || []).map((w) => w.prs_merged || 0),
+          week_totals: t.week_totals || [],
         });
       }
     });
     return merged;
   }, [members, team]);
 
-  const sorted = useMemo(() => {
-    const arr = [...rows];
+  const pillarNames = useMemo(() => {
+    const set = new Set();
+    rows.forEach((r) => { if (r.pillar) set.add(r.pillar); });
+    return [...set].sort();
+  }, [rows]);
+
+  const filteredRows = useMemo(() => {
+    if (pillarFilter === 'all') return rows;
+    if (pillarFilter === '__unassigned') return rows.filter((r) => !r.pillar);
+    return rows.filter((r) => r.pillar === pillarFilter);
+  }, [rows, pillarFilter]);
+
+  const sortedRows = useMemo(() => {
+    const arr = [...filteredRows];
     arr.sort((a, b) => {
       const av = a[sortKey] ?? 0;
       const bv = b[sortKey] ?? 0;
@@ -430,7 +454,7 @@ export default function TeamAnalytics() {
       return 0;
     });
     return arr;
-  }, [rows, sortKey, sortDir]);
+  }, [filteredRows, sortKey, sortDir]);
 
   const handleSort = (k) => {
     if (k === sortKey) setSortDir(sortDir === 'asc' ? 'desc' : 'asc');
@@ -440,42 +464,70 @@ export default function TeamAnalytics() {
     }
   };
 
-  const selectMember = useCallback((id) => {
+  const goToTab = useCallback((next, id = selectedID) => {
+    if (next === 'member' && !id) {
+      setTab('team');
+      writeURLState({ tab: 'team', id: '' });
+      return;
+    }
+    setTab(next);
+    writeURLState({ tab: next, id: next === 'member' ? id : '' });
+  }, [selectedID]);
+
+  const openMember = useCallback((id) => {
     setSelectedID(id);
-    writeQueryMember(id);
+    setTab('member');
+    writeURLState({ tab: 'member', id });
   }, []);
 
-  const closeProfile = useCallback(() => selectMember(''), [selectMember]);
-
-  // Resolve the row that backs the open profile. Falls back to a stub
-  // if the id was deep-linked but isn't in the directory yet.
-  const selectedRow = useMemo(() => {
-    if (!selectedID) return null;
-    return rows.find((r) => r.id === selectedID) || { id: selectedID, name: selectedID, github: '', pillar: '' };
-  }, [selectedID, rows]);
-
-  const onProfileSaved = useCallback(() => {
-    // Re-fetch the team-overview + members directory so the table
-    // reflects the updated github_login. Numbers may not have changed
-    // yet (rebuild is async), but the avatar/login row will.
-    setReloadTick((t) => t + 1);
-  }, []);
+  const onSavedMember = useCallback(() => setReloadTick((t) => t + 1), []);
 
   const empty = !loading && rows.length === 0;
 
   return (
     <div className="ta-root">
-      <header className="ta-head">
+      <header className="ta-mast">
         <div>
-          <div className="ta-eyebrow">N° 03 · TEAM ANALYTICS</div>
-          <h1 className="ta-title">Velocity, contributions, evolution.</h1>
-          <p className="ta-sub">Last 12 weeks · Jira completions + GitHub PRs + reviews</p>
+          <span className="ta-mast__bracket">N° 03 · TEAM ANALYTICS</span>
+          <h1 className="ta-mast__title">Velocity, <em>contributions</em>, evolution.</h1>
+          <p className="ta-mast__sub">Roadmap Planner · Last 12 weeks · Jira completions + GitHub PRs + reviews</p>
         </div>
-        <div className="ta-status">
-          <StatusBadge source="jira"   info={status?.jira} />
-          <StatusBadge source="github" info={status?.github} />
+        <div>
+          <p className="ta-mast__meta">
+            Source <strong>Jira + GitHub</strong> · Window <strong>12 weeks</strong>
+          </p>
+          <div className="ta-status">
+            <StatusBadge source="jira"   info={status?.jira} />
+            <StatusBadge source="github" info={status?.github} />
+          </div>
         </div>
       </header>
+
+      <nav className="ta-tabs" role="tablist">
+        <button
+          className={`ta-tab${tab === 'team' ? ' is-active' : ''}`}
+          onClick={() => goToTab('team')}
+          role="tab"
+        >
+          <span className="ta-tab__num">01</span>Team overview
+        </button>
+        <button
+          className={`ta-tab${tab === 'member' ? ' is-active' : ''}`}
+          onClick={() => goToTab('member')}
+          disabled={!selectedID}
+          role="tab"
+          title={selectedID ? '' : 'Select a member from the team table first'}
+        >
+          <span className="ta-tab__num">02</span>Member profile
+        </button>
+        <button
+          className={`ta-tab${tab === 'slice' ? ' is-active' : ''}`}
+          onClick={() => goToTab('slice')}
+          role="tab"
+        >
+          <span className="ta-tab__num">03</span>Slice explorer
+        </button>
+      </nav>
 
       {error && <div className="ta-banner ta-banner--bad">Failed to load: {error}</div>}
 
@@ -484,80 +536,542 @@ export default function TeamAnalytics() {
           <h3>No analytics data yet</h3>
           <p>
             This view shows once <code>storage.enabled</code> is on and the collector has
-            captured at least one cycle. See{' '}
-            <a href="/docs/team-analytics/PROPOSAL.md" target="_blank" rel="noreferrer">
-              docs/team-analytics/PROPOSAL.md
-            </a>
-            {' '}for setup.
-          </p>
-          <p className="ta-sub">
-            For a preview of what this view will look like with data, open{' '}
-            <a href="/docs/team-analytics/prototype.html" target="_blank" rel="noreferrer">
-              docs/team-analytics/prototype.html
-            </a>.
+            captured at least one cycle.
           </p>
         </div>
       )}
 
-      {!empty && (
-        <div className="ta-panel">
-          <table className="ta-table">
-            <thead>
-              <tr>
-                {COLUMNS.map((c) => (
-                  <th
-                    key={c.key}
-                    className={`ta-th ta-th--${c.align}${sortKey === c.key ? ' is-sorted' : ''}${c.sortable ? ' is-sortable' : ''}`}
-                    onClick={() => c.sortable && handleSort(c.key)}
-                  >
-                    {c.label}
-                    {sortKey === c.key && <span className="ta-arrow">{sortDir === 'asc' ? '↑' : '↓'}</span>}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {sorted.map((m) => {
-                const initials = initialsOf(m.name);
-                const points = Number.isFinite(m.points) ? m.points.toFixed(1) : '0.0';
-                const isSel = m.id === selectedID;
-                return (
-                  <tr
-                    key={m.id}
-                    className={`ta-row${isSel ? ' is-selected' : ''}${m.active === false ? ' is-inactive' : ''}`}
-                    onClick={() => selectMember(m.id)}
-                    title="Open profile"
-                  >
-                    <td className="ta-td ta-td--member">
-                      <span className="ta-avatar">{initials}</span>
+      {!empty && tab === 'team' && (
+        <TeamView
+          rows={sortedRows}
+          pillarNames={pillarNames}
+          pillarFilter={pillarFilter}
+          onPillarFilter={setPillarFilter}
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={handleSort}
+          onRowClick={openMember}
+          loading={loading}
+          pillars={pillars}
+          network={network}
+        />
+      )}
+
+      {!empty && tab === 'member' && (
+        <MemberView
+          memberRow={rows.find((r) => r.id === selectedID)}
+          onBack={() => goToTab('team')}
+          onSaved={onSavedMember}
+          allRows={rows}
+          onSwitchMember={openMember}
+        />
+      )}
+
+      {!empty && tab === 'slice' && (
+        <SliceView rows={rows} />
+      )}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------- */
+/*  Team Overview tab                                                    */
+/* -------------------------------------------------------------------- */
+
+function TeamView({ rows, pillarNames, pillarFilter, onPillarFilter, sortKey, sortDir, onSort, onRowClick, loading, pillars, network }) {
+  return (
+    <>
+      <div className="ta-panel">
+        <header className="ta-panel__head">
+          <div>
+            <div className="ta-panel__title">All members · last 12 weeks</div>
+            <div className="ta-panel__sub">Sortable. Click a row for the member profile.</div>
+          </div>
+          <div className="ta-filters">
+            <span className="ta-filters__lbl">Pillar</span>
+            <button
+              type="button"
+              className={`ta-pill${pillarFilter === 'all' ? ' is-active' : ''}`}
+              onClick={() => onPillarFilter('all')}
+            >All</button>
+            {pillarNames.map((p) => (
+              <button key={p} type="button"
+                className={`ta-pill${pillarFilter === p ? ' is-active' : ''}`}
+                onClick={() => onPillarFilter(p)}
+              >{p}</button>
+            ))}
+            <button
+              type="button"
+              className={`ta-pill${pillarFilter === '__unassigned' ? ' is-active' : ''}`}
+              onClick={() => onPillarFilter('__unassigned')}
+            >Unassigned</button>
+          </div>
+        </header>
+        <table className="ta-tbl">
+          <thead>
+            <tr>
+              {TABLE_COLS.map((c) => (
+                <th key={c.key}
+                    className={[
+                      c.align === 'right' ? 'right' : '',
+                      sortKey === c.key ? 'is-sorted' : '',
+                      c.sortable ? '' : 'no-sort',
+                    ].join(' ').trim()}
+                    onClick={() => c.sortable && onSort(c.key)}>
+                  {c.label}
+                  {sortKey === c.key && c.sortable && (
+                    <span style={{ marginLeft: 4 }}>{sortDir === 'asc' ? '↑' : '↓'}</span>
+                  )}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((m) => {
+              const sparkValues = (m.week_totals || []).map((w) => w.prs_merged || 0);
+              const dJira    = computeDelta(m.week_totals, 'jira_done');
+              const dPRs     = computeDelta(m.week_totals, 'prs_merged');
+              const dReviews = computeDelta(m.week_totals, 'reviews');
+              const points = Number.isFinite(m.points) ? (+m.points).toFixed(1) : '0.0';
+              return (
+                <tr key={m.id}
+                    className={`row-link${m.active === false ? ' is-inactive' : ''}`}
+                    onClick={() => onRowClick(m.id)}>
+                  <td>
+                    <div className="ta-cell-member">
+                      <span className="ta-avatar">{initialsOf(m.name)}</span>
                       <div>
                         <div className="ta-name">{m.name}</div>
-                        {m.github && <div className="ta-meta mono">@{m.github}</div>}
+                        {m.github && <div className="ta-meta">@{m.github}</div>}
                       </div>
-                    </td>
-                    <td className="ta-td ta-td--right mono">{m.jira}</td>
-                    <td className="ta-td ta-td--right mono">{points}</td>
-                    <td className="ta-td ta-td--right mono">{m.prs}</td>
-                    <td className="ta-td ta-td--right mono">{m.reviews}</td>
-                    <td className="ta-td ta-td--right mono">{formatHours(m.latency)}</td>
-                    <td className="ta-td"><Spark values={m.spark} color="var(--accent, #b8443c)" /></td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-          {loading && <div className="ta-loading">Loading…</div>}
+                    </div>
+                  </td>
+                  <td><span className="ta-meta">{m.pillar || '—'}</span></td>
+                  <td className="ta-right"><span className="ta-num">{m.jira}</span><DeltaPill d={dJira} /></td>
+                  <td className="ta-right"><span className="ta-num">{points}</span></td>
+                  <td className="ta-right"><span className="ta-num">{m.prs}</span><DeltaPill d={dPRs} /></td>
+                  <td className="ta-right"><span className="ta-num">{m.reviews}</span><DeltaPill d={dReviews} /></td>
+                  <td className="ta-right"><span className="ta-num">{formatHours(m.latency)}</span></td>
+                  <td><Spark values={sparkValues} color="var(--ta-accent, #b8443c)" /></td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+        {loading && <div className="ta-loading">Loading…</div>}
+      </div>
+
+      <div className="ta-row">
+        <div className="ta-panel">
+          <header className="ta-panel__head">
+            <div className="ta-panel__title">Throughput, by pillar</div>
+            <div className="ta-panel__sub">PRs merged · 12-week stack</div>
+          </header>
+          <div className="ta-chartwrap">
+            <PillarStack buckets={pillars} />
+          </div>
         </div>
-      )}
+        <div className="ta-panel">
+          <header className="ta-panel__head">
+            <div className="ta-panel__title">Review network density</div>
+            <div className="ta-panel__sub">Who reviews whom</div>
+          </header>
+          <NetworkPanel network={network} />
+        </div>
+      </div>
+    </>
+  );
+}
 
-      {selectedRow && (
-        <MemberProfile row={selectedRow} onClose={closeProfile} onSaved={onProfileSaved} />
-      )}
+/* -------------------------------------------------------------------- */
+/*  Member Profile tab                                                   */
+/* -------------------------------------------------------------------- */
 
-      <footer className="ta-foot">
-        <span className="mono">SCOPE · B2</span>
-        <span>Member profile + manual GitHub linking · Slice Explorer (B3) is next.</span>
-      </footer>
+function MemberView({ memberRow, onBack, onSaved, allRows, onSwitchMember }) {
+  const [detail, setDetail] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [editGh, setEditGh] = useState('');
+  const [editPillar, setEditPillar] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const id = memberRow?.id;
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const d = await contributionsAPI.member(id);
+        if (cancelled) return;
+        setDetail(d);
+        setEditGh(pick(d.info, 'github_login', 'GitHubLogin') || memberRow.github || '');
+        setEditPillar(pick(d.info, 'pillar_id', 'PillarID') || memberRow.pillar || '');
+      } catch (e) {
+        if (cancelled) return;
+        toast.error(`Profile load: ${handleAPIError(e).message}`);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => { cancelled = true; };
+  }, [id, memberRow?.github, memberRow?.pillar]);
+
+  if (!memberRow) {
+    return (
+      <div className="ta-panel">
+        <div className="ta-empty">
+          <h3>No member selected</h3>
+          <p>Pick a row from the Team Overview tab to drill in.</p>
+          <p className="ta-meta">
+            <button type="button" className="ta-btn" onClick={onBack}>← back to team</button>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const info = detail?.info || {};
+  const totals = {
+    jira:    detail?.jira_issues_done ?? memberRow.jira ?? 0,
+    points:  detail?.jira_points_done ?? memberRow.points ?? 0,
+    prs:     detail?.prs_merged ?? memberRow.prs ?? 0,
+    reviews: detail?.prs_reviewed ?? memberRow.reviews ?? 0,
+  };
+  const weeks = detail?.week_totals || memberRow.week_totals || [];
+  const components = detail?.components_touched || [];
+  const sprint = detail?.sprint || null;
+
+  const dirty =
+    String(editGh || '').toLowerCase() !== String(pick(info, 'github_login', 'GitHubLogin') || '').toLowerCase() ||
+    String(editPillar || '') !== String(pick(info, 'pillar_id', 'PillarID') || '');
+
+  const onSave = async () => {
+    setSaving(true);
+    try {
+      const updated = await contributionsAPI.updateMember(id, {
+        github_login: (editGh || '').trim(),
+        pillar_id:    (editPillar || '').trim(),
+      });
+      toast.success('Saved · rebuilding rollups in background');
+      setDetail((prev) => ({ ...(prev || {}), info: updated }));
+      onSaved?.(updated);
+    } catch (e) {
+      toast.error(`Save failed: ${handleAPIError(e).message}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const compMax = Math.max(1, ...components.map((c) => c.issues || 0));
+  const sortedRoster = [...allRows].sort((a, b) => a.name.localeCompare(b.name));
+
+  return (
+    <>
+      <button type="button" className="ta-backlink" onClick={onBack}>
+        ← Back to team overview
+      </button>
+
+      <div className="ta-profile-grid">
+        <aside className="ta-profile-card">
+          <div className="ta-profile-avatar">{initialsOf(memberRow.name)}</div>
+          <div className="ta-profile-name">{pick(info, 'display_name', 'DisplayName') || memberRow.name}</div>
+          <div className="ta-profile-pillar">{(memberRow.pillar || 'unassigned').toUpperCase()}</div>
+          <div className="ta-profile-handles">
+            <div>github · {memberRow.github ? `@${memberRow.github}` : <em style={{ color: 'var(--ta-fg-muted)' }}>not linked</em>}</div>
+            <div>jira · {memberRow.email || pick(info, 'email', 'Email') || '—'}</div>
+          </div>
+          <div className="ta-kpi-grid">
+            <div className="ta-kpi"><div className="ta-kpi__lbl">Jira done</div><div className="ta-kpi__val">{totals.jira}</div></div>
+            <div className="ta-kpi"><div className="ta-kpi__lbl">Story pts</div><div className="ta-kpi__val">{Number.isFinite(totals.points) ? (+totals.points).toFixed(0) : '0'}</div></div>
+            <div className="ta-kpi"><div className="ta-kpi__lbl">PRs merged</div><div className="ta-kpi__val">{totals.prs}</div></div>
+            <div className="ta-kpi"><div className="ta-kpi__lbl">Reviews</div><div className="ta-kpi__val">{totals.reviews}</div></div>
+          </div>
+        </aside>
+
+        <div>
+          <div className="ta-card">
+            <h3 className="ta-card__title">Weekly contribution
+              <span className="ta-legend">
+                <span><i style={{ background: 'var(--ta-accent, #b8443c)' }} />PRs merged</span>
+                <span><i style={{ background: '#2c5d75' }} />Jira done</span>
+                <span><i style={{ background: '#b87a1a' }} />Reviews</span>
+              </span>
+            </h3>
+            <div className="ta-card__sub">Last {weeks.length || 12} weeks · counts per ISO week</div>
+            <TrendChart weeks={weeks} />
+          </div>
+
+          <div className="ta-card">
+            <h3 className="ta-card__title">Components touched
+              <span className="ta-legend"><span style={{ fontFamily: 'var(--ta-mono)' }}>Each row = one component · width = issues</span></span>
+            </h3>
+            <div className="ta-card__sub">Where this member spent their work in the window</div>
+            {components.length === 0 ? (
+              <p className="ta-meta">No components recorded for this member yet — Jira issues need a Component value.</p>
+            ) : (
+              components.map((c) => (
+                <div key={c.component} className="ta-bar-row">
+                  <div className="ta-bar-label">{c.component}</div>
+                  <div className="ta-bar-track">
+                    <div className="ta-bar-fill" style={{ width: `${(c.issues / compMax) * 100}%` }} />
+                  </div>
+                  <div className="ta-bar-num">{c.issues}</div>
+                </div>
+              ))
+            )}
+          </div>
+
+          <div className="ta-card">
+            <h3 className="ta-card__title">This sprint
+              <span className="ta-pill" style={{ background: 'var(--ta-bg-soft)' }}>
+                {sprint?.name || '—'}
+              </span>
+            </h3>
+            <div className="ta-card__sub">Live · refreshes with the next collection cycle</div>
+            <div className="ta-sprint-grid">
+              <div><div className="ta-kpi__lbl">In progress</div><div className="ta-num ta-num--lg">{sprint?.wip ?? '—'}</div></div>
+              <div><div className="ta-kpi__lbl">Done</div><div className="ta-num ta-num--lg">{sprint?.done ?? '—'}</div></div>
+              <div><div className="ta-kpi__lbl">PRs open</div><div className="ta-num ta-num--lg">{sprint?.prs_open ?? '—'}</div></div>
+              <div><div className="ta-kpi__lbl">PRs merged</div><div className="ta-num ta-num--lg">{sprint?.prs_merged ?? '—'}</div></div>
+            </div>
+          </div>
+
+          <div className="ta-card">
+            <h3 className="ta-card__title">Identity
+              <span className="ta-meta">edit · save triggers an aggregator rebuild</span>
+            </h3>
+            <div className="ta-card__sub">Map this member to a GitHub login + pillar so PRs and review counts show up</div>
+            <div className="ta-edit-grid">
+              <label className="ta-field">
+                <span className="ta-field-label">Member ID</span>
+                <input className="ta-input ta-input--ro" value={memberRow.id} readOnly />
+                <span className="ta-field-help">Stable internal slug — derived from email at first sync.</span>
+              </label>
+              <label className="ta-field">
+                <span className="ta-field-label">Email (Jira)</span>
+                <input className="ta-input ta-input--ro" value={pick(info, 'email', 'Email') || memberRow.email || ''} readOnly />
+              </label>
+              <label className="ta-field">
+                <span className="ta-field-label">Jira Account ID</span>
+                <input className="ta-input ta-input--ro" value={pick(info, 'jira_account_id', 'JiraAccountID') || memberRow.jira_account_id || ''} readOnly />
+              </label>
+              <label className="ta-field">
+                <span className="ta-field-label">GitHub login</span>
+                <input className="ta-input"
+                       value={editGh}
+                       onChange={(e) => setEditGh(e.target.value)}
+                       placeholder="alicetan"
+                       autoComplete="off"
+                       spellCheck={false} />
+                <span className="ta-field-help">Empty = no GitHub link.</span>
+              </label>
+              <label className="ta-field">
+                <span className="ta-field-label">Pillar</span>
+                <input className="ta-input"
+                       value={editPillar}
+                       onChange={(e) => setEditPillar(e.target.value)}
+                       placeholder="essentials" />
+                <span className="ta-field-help">Free-form. Drives the Team filter pills + pillar stack chart.</span>
+              </label>
+            </div>
+            <div className="ta-form-actions">
+              {loading && <span className="ta-field-help">Loading…</span>}
+              {saving && <span className="ta-field-help">Saving…</span>}
+              <button type="button" className="ta-btn" onClick={onBack}>Cancel</button>
+              <button type="button" className="ta-btn ta-btn--primary" onClick={onSave}
+                      disabled={!dirty || saving || loading}>Save</button>
+            </div>
+          </div>
+
+          <div className="ta-card">
+            <h3 className="ta-card__title">Switch member</h3>
+            <div className="ta-card__sub">Jump straight to another profile without going back</div>
+            <select className="ta-input" value={memberRow.id} onChange={(e) => onSwitchMember(e.target.value)}>
+              {sortedRoster.map((r) => (
+                <option key={r.id} value={r.id}>{r.name}{r.pillar ? ` · ${r.pillar}` : ''}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+/* -------------------------------------------------------------------- */
+/*  Slice Explorer tab                                                   */
+/* -------------------------------------------------------------------- */
+
+const SLICE_METRICS = [
+  { val: 'prs',     label: 'PRs merged' },
+  { val: 'jira',    label: 'Jira done'  },
+  { val: 'points',  label: 'Story pts'  },
+];
+const SLICE_ROW_AXES = [
+  { val: 'pillar', label: 'Pillar' },
+  { val: 'member', label: 'Member' },
+];
+const SLICE_COL_AXES = [
+  { val: 'week',    label: 'Week'    },
+  { val: 'quarter', label: 'Quarter' },
+];
+
+function SliceView({ rows }) {
+  const [rowsAxis, setRowsAxis] = useState('pillar');
+  const [colsAxis, setColsAxis] = useState('week');
+  const [metric,   setMetric]   = useState('prs');
+
+  const allWeeks = useMemo(() => {
+    const set = new Map();
+    rows.forEach((r) => (r.week_totals || []).forEach((w) => set.set(w.week_start, true)));
+    return [...set.keys()].sort();
+  }, [rows]);
+
+  const seriesByMember = useMemo(() => {
+    const out = new Map();
+    rows.forEach((r) => {
+      const byWeek = new Map((r.week_totals || []).map((w) => [w.week_start, w]));
+      out.set(r.id, allWeeks.map((wk) => byWeek.get(wk) || { jira_done: 0, prs_merged: 0, reviews: 0 }));
+    });
+    return out;
+  }, [rows, allWeeks]);
+
+  const metricGetter = useCallback((b) => {
+    if (metric === 'jira')   return b.jira_done   || 0;
+    if (metric === 'points') return 0;
+    return b.prs_merged || 0;
+  }, [metric]);
+
+  const rowKeys = useMemo(() => {
+    if (rowsAxis === 'member') {
+      return rows.slice().sort((a, b) => a.name.localeCompare(b.name)).map((r) => r.id);
+    }
+    const set = new Set();
+    rows.forEach((r) => set.add(r.pillar || 'Unassigned'));
+    return [...set].sort();
+  }, [rows, rowsAxis]);
+
+  const cols = useMemo(() => {
+    if (colsAxis === 'week') {
+      return allWeeks.map((wk, i) => ({ key: wk, label: `w${i + 1}` }));
+    }
+    const chunkSize = Math.max(1, Math.ceil(allWeeks.length / 4));
+    const out = [];
+    for (let i = 0; i < 4; i++) {
+      const start = i * chunkSize;
+      const end = Math.min(allWeeks.length, start + chunkSize);
+      if (start >= end) break;
+      out.push({ key: `q${i}`, label: `Q${i + 1}`, range: [start, end] });
+    }
+    return out;
+  }, [allWeeks, colsAxis]);
+
+  const matrix = useMemo(() => rowKeys.map((rk) => {
+    const matches = rowsAxis === 'member'
+      ? rows.filter((r) => r.id === rk)
+      : rows.filter((r) => (r.pillar || 'Unassigned') === rk);
+    const cells = cols.map((col) => {
+      if (colsAxis === 'week') {
+        if (metric === 'points') return 0;
+        const idx = allWeeks.indexOf(col.key);
+        if (idx < 0) return 0;
+        return matches.reduce((acc, r) => {
+          const series = seriesByMember.get(r.id) || [];
+          return acc + metricGetter(series[idx] || {});
+        }, 0);
+      }
+      const [start, end] = col.range;
+      if (metric === 'points') {
+        const perQuarter = matches.reduce((acc, r) => acc + (r.points || 0), 0) / Math.max(1, cols.length);
+        return Math.round(perQuarter);
+      }
+      return matches.reduce((acc, r) => {
+        const series = seriesByMember.get(r.id) || [];
+        return acc + series.slice(start, end).reduce((s, b) => s + metricGetter(b), 0);
+      }, 0);
+    });
+    const max = Math.max(1, ...cells);
+    const total = cells.reduce((a, b) => a + b, 0);
+    return { rowKey: rk, cells, max, total };
+  }), [rowKeys, cols, rows, rowsAxis, colsAxis, metric, seriesByMember, allWeeks, metricGetter]);
+
+  const labelOfRow = (rk) => {
+    if (rowsAxis === 'member') {
+      const r = rows.find((x) => x.id === rk);
+      return r ? r.name : rk;
+    }
+    return rk;
+  };
+
+  return (
+    <div className="ta-panel">
+      <header className="ta-panel__head">
+        <div>
+          <div className="ta-panel__title">Slice explorer</div>
+          <div className="ta-panel__sub">2 axes + 1 metric. Always.</div>
+        </div>
+      </header>
+
+      <div className="ta-slice-filters">
+        <span className="ta-filters__lbl">Rows</span>
+        <div className="ta-seg">
+          {SLICE_ROW_AXES.map((o) => (
+            <button key={o.val}
+                    className={rowsAxis === o.val ? 'is-active' : ''}
+                    onClick={() => setRowsAxis(o.val)}>{o.label}</button>
+          ))}
+        </div>
+        <span className="ta-filters__lbl" style={{ marginLeft: 12 }}>Cols</span>
+        <div className="ta-seg">
+          {SLICE_COL_AXES.map((o) => (
+            <button key={o.val}
+                    className={colsAxis === o.val ? 'is-active' : ''}
+                    onClick={() => setColsAxis(o.val)}>{o.label}</button>
+          ))}
+        </div>
+        <span className="ta-filters__lbl" style={{ marginLeft: 12 }}>Metric</span>
+        <div className="ta-seg">
+          {SLICE_METRICS.map((o) => (
+            <button key={o.val}
+                    className={metric === o.val ? 'is-active' : ''}
+                    onClick={() => setMetric(o.val)}>{o.label}</button>
+          ))}
+        </div>
+      </div>
+
+      <div className="ta-pivot-wrap">
+        <table className="ta-pivot">
+          <thead>
+            <tr>
+              <th>{rowsAxis.toUpperCase()}</th>
+              {cols.map((c) => <th key={c.key}>{c.label}</th>)}
+              <th>Σ</th>
+            </tr>
+          </thead>
+          <tbody>
+            {matrix.map((row) => (
+              <tr key={row.rowKey}>
+                <td>{labelOfRow(row.rowKey)}</td>
+                {row.cells.map((v, i) => (
+                  <td key={i}
+                      className={`heat${v === 0 ? ' heat-zero' : ''}`}
+                      style={{ '--h': (v / row.max).toFixed(2) }}>
+                    <span>{v}</span>
+                  </td>
+                ))}
+                <td style={{ fontWeight: 600 }}>{row.total}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="ta-pivot-foot">
+        Heat is per-row max. Cells are absolute counts. Story-points by week is left
+        empty because the rollup keeps total points only — switch to "Quarter" for
+        an even split, or use the Team Overview column.
+      </div>
     </div>
   );
 }

--- a/roadmap-planner/frontend/src/components/TeamAnalytics.jsx
+++ b/roadmap-planner/frontend/src/components/TeamAnalytics.jsx
@@ -1070,6 +1070,15 @@ const SLICE_COL_AXES = [
   { val: 'quarter', label: 'Quarter' },
 ];
 
+// formatCell renders a slice cell. Story points can be fractional (Jira lets
+// estimators set 0.5, 1.5, …) so we keep one decimal when it would matter
+// and trim it otherwise. PR/Jira counts are always integers.
+function formatCell(v, metric) {
+  if (metric !== 'points') return v;
+  const n = Number(v) || 0;
+  return Number.isInteger(n) ? n : n.toFixed(1);
+}
+
 function SliceView({ rows, orderedPillarNames, pillarBuckets }) {
   const [rowsAxis, setRowsAxis] = useState('pillar');
   const [colsAxis, setColsAxis] = useState('week');
@@ -1088,7 +1097,7 @@ function SliceView({ rows, orderedPillarNames, pillarBuckets }) {
     const out = new Map();
     rows.forEach((r) => {
       const byWeek = new Map((r.week_totals || []).map((w) => [w.week_start, w]));
-      out.set(r.id, allWeeks.map((wk) => byWeek.get(wk) || { jira_done: 0, prs_merged: 0, reviews: 0 }));
+      out.set(r.id, allWeeks.map((wk) => byWeek.get(wk) || { jira_done: 0, points: 0, prs_merged: 0, reviews: 0 }));
     });
     return out;
   }, [rows, allWeeks]);
@@ -1106,14 +1115,14 @@ function SliceView({ rows, orderedPillarNames, pillarBuckets }) {
     });
     const aligned = new Map();
     out.forEach((byWeek, pillar) => {
-      aligned.set(pillar, allWeeks.map((wk) => byWeek.get(wk) || { jira_done: 0, prs_merged: 0 }));
+      aligned.set(pillar, allWeeks.map((wk) => byWeek.get(wk) || { jira_done: 0, points: 0, prs_merged: 0 }));
     });
     return aligned;
   }, [pillarBuckets, allWeeks]);
 
   const metricGetter = useCallback((b) => {
     if (metric === 'jira')   return b.jira_done   || 0;
-    if (metric === 'points') return 0;
+    if (metric === 'points') return b.points      || 0;
     return b.prs_merged || 0;
   }, [metric]);
 
@@ -1151,19 +1160,16 @@ function SliceView({ rows, orderedPillarNames, pillarBuckets }) {
       if (rowsAxis === 'pillar') {
         const series = seriesByPillar.get(rk) || allWeeks.map(() => ({}));
         if (colsAxis === 'week') {
-          if (metric === 'points') return 0;
           const idx = allWeeks.indexOf(col.key);
           if (idx < 0) return 0;
           return metricGetter(series[idx] || {});
         }
         const [start, end] = col.range;
-        if (metric === 'points') return 0;
         return series.slice(start, end).reduce((s, b) => s + metricGetter(b), 0);
       }
       // Member axis — sum the member's week_totals series.
       const matches = rows.filter((r) => r.id === rk);
       if (colsAxis === 'week') {
-        if (metric === 'points') return 0;
         const idx = allWeeks.indexOf(col.key);
         if (idx < 0) return 0;
         return matches.reduce((acc, r) => {
@@ -1172,10 +1178,6 @@ function SliceView({ rows, orderedPillarNames, pillarBuckets }) {
         }, 0);
       }
       const [start, end] = col.range;
-      if (metric === 'points') {
-        const perQuarter = matches.reduce((acc, r) => acc + (r.points || 0), 0) / Math.max(1, cols.length);
-        return Math.round(perQuarter);
-      }
       return matches.reduce((acc, r) => {
         const series = seriesByMember.get(r.id) || [];
         return acc + series.slice(start, end).reduce((s, b) => s + metricGetter(b), 0);
@@ -1247,19 +1249,19 @@ function SliceView({ rows, orderedPillarNames, pillarBuckets }) {
                   <td key={i}
                       className={`heat${v === 0 ? ' heat-zero' : ''}`}
                       style={{ '--h': (v / row.max).toFixed(2) }}>
-                    <span>{v}</span>
+                    <span>{formatCell(v, metric)}</span>
                   </td>
                 ))}
-                <td style={{ fontWeight: 600 }}>{row.total}</td>
+                <td style={{ fontWeight: 600 }}>{formatCell(row.total, metric)}</td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
       <div className="ta-pivot-foot">
-        Heat is per-row max. Cells are absolute counts. Story-points by week is left
-        empty because the rollup keeps total points only — switch to "Quarter" for
-        an even split, or use the Team Overview column.
+        Heat is per-row max. Cells are absolute counts. Story points are summed by
+        each item's resolved-week and fanned out across pillars when an issue or PR
+        attributes to more than one.
       </div>
     </div>
   );

--- a/roadmap-planner/frontend/src/components/TeamAnalytics.jsx
+++ b/roadmap-planner/frontend/src/components/TeamAnalytics.jsx
@@ -10,22 +10,34 @@
  *   3. Slice explorer  — pivot of (member|pillar) × (week|quarter)
  *                        on (PRs merged|Jira done|Story pts) with heat tint.
  *
- * Tab + selected member are reflected into ?tab=…&member=… so the view
- * is deep-linkable and the browser's back button works as expected.
+ * Pillar provenance: the same Jira "Pillar" issue type the roadmap tab
+ * uses, fetched via /api/basic. Each member's pillar is derived from
+ * their components_touched set by majority match against
+ * BasicPillar.component. The legacy free-form members.pillar_id is kept
+ * as an explicit override on the profile form.
+ *
+ * Theming: every visual var comes from styles/theme.css semantic tokens
+ * (--bg, --fg, --border, --accent, --ocean, --amber, --forest, …) so
+ * light / dark / Atlas modes flip automatically.
  */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import toast from 'react-hot-toast';
-import { contributionsAPI, handleAPIError } from '../services/api';
+import { contributionsAPI, handleAPIError, roadmapAPI } from '../services/api';
 import './TeamAnalytics.css';
 
 /* -------------------------------------------------------------------- */
 /*  Generic helpers                                                      */
 /* -------------------------------------------------------------------- */
 
-const PILLAR_COLORS = {
-  Unassigned: '#a39a8a',
+// Theme-token series colors. CSS custom properties resolve at paint-time
+// against the active [data-theme]/[data-mode], so dark mode + Atlas
+// theme just work without per-mode branching here.
+const SERIES_COLOR = {
+  prs:     'var(--accent)',
+  jira:    'var(--ocean)',
+  reviews: 'var(--amber)',
 };
-const SERIES_PALETTE = ['#b8443c', '#2c5d75', '#b87a1a', '#3a6d4b', '#7a4f9c', '#9c4f4f', '#4f7f9c'];
+const PILLAR_PALETTE = ['var(--accent)', 'var(--ocean)', 'var(--amber)', 'var(--forest)', 'var(--crimson)'];
 
 const formatHours = (h) => (h == null ? '—' : `${(+h).toFixed(1)}h`);
 const formatPct = (p) => (p == null || isNaN(p) ? '—' : `${Math.round(p)}%`);
@@ -52,12 +64,52 @@ const initialsOf = (name) =>
     .join('')
     .toUpperCase() || '?';
 
-const colorForPillar = (p, fallbackIdx = 0) => {
-  if (!p) return PILLAR_COLORS.Unassigned;
-  if (PILLAR_COLORS[p]) return PILLAR_COLORS[p];
+/* -------------------------------------------------------------------- */
+/*  Pillar derivation — same source the roadmap tab uses                 */
+/* -------------------------------------------------------------------- */
+
+// buildComponentToPillar takes the BasicPillar list from /api/basic and
+// returns a Map: lowercased component name → pillar name. Used to
+// classify members by the components they've touched.
+const buildComponentToPillar = (basicPillars) => {
+  const m = new Map();
+  (basicPillars || []).forEach((p) => {
+    const comp = (p.component || '').trim().toLowerCase();
+    if (comp) m.set(comp, p.name);
+  });
+  return m;
+};
+
+// derivePillarForMember picks the pillar with the most component matches
+// from the member's component set. Falls back to the operator-set
+// override (member.pillar_id) when no match, then to ''.
+const derivePillarForMember = (memberComponents, override, compToPillar) => {
+  if (override) return override;
+  if (!memberComponents || memberComponents.length === 0) return '';
+  const tally = new Map();
+  memberComponents.forEach((c) => {
+    const key = (c || '').trim().toLowerCase();
+    const pillar = compToPillar.get(key);
+    if (pillar) tally.set(pillar, (tally.get(pillar) || 0) + 1);
+  });
+  if (tally.size === 0) return '';
+  let best = '', bestN = -1;
+  for (const [p, n] of tally) {
+    if (n > bestN) { best = p; bestN = n; }
+  }
+  return best;
+};
+
+const colorForPillar = (pillarName, allPillars) => {
+  if (!pillarName) return 'var(--fg-faint)';
+  // Stable index from the ordered pillar list (preserves the order the
+  // roadmap tab shows). Falls back to a hash-derived index when the
+  // pillar isn't in the basic data.
+  const idx = (allPillars || []).indexOf(pillarName);
+  if (idx >= 0) return PILLAR_PALETTE[idx % PILLAR_PALETTE.length];
   let h = 0;
-  for (let i = 0; i < p.length; i++) h = (h * 31 + p.charCodeAt(i)) >>> 0;
-  return SERIES_PALETTE[(h + fallbackIdx) % SERIES_PALETTE.length];
+  for (let i = 0; i < pillarName.length; i++) h = (h * 31 + pillarName.charCodeAt(i)) >>> 0;
+  return PILLAR_PALETTE[h % PILLAR_PALETTE.length];
 };
 
 /* -------------------------------------------------------------------- */
@@ -92,7 +144,7 @@ const writeURLState = ({ tab, id }) => {
 };
 
 /* -------------------------------------------------------------------- */
-/*  Delta indicator (last-4 vs prior-4 weeks)                            */
+/*  Delta indicator                                                      */
 /* -------------------------------------------------------------------- */
 
 const computeDelta = (series, key) => {
@@ -115,43 +167,55 @@ function DeltaPill({ d }) {
 }
 
 /* -------------------------------------------------------------------- */
-/*  Sparkline (table cell)                                               */
+/*  Sparkline                                                            */
 /* -------------------------------------------------------------------- */
 
-function Spark({ values, color = 'currentColor', width = 110, height = 28 }) {
-  if (!values || values.length === 0) {
-    return <span className="ta-meta">—</span>;
-  }
+function Spark({ values, width = 110, height = 28 }) {
+  if (!values || values.length === 0) return <span className="ta-meta">—</span>;
   const max = Math.max(1, ...values);
   const step = (width - 4) / Math.max(1, values.length - 1);
   const pts = values.map((v, i) => `${2 + i * step},${height - 2 - (v / max) * (height - 4)}`);
   const last = pts[pts.length - 1].split(',');
   return (
     <svg className="ta-spark" width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
-      <polyline fill="none" stroke={color} strokeWidth="1.4" points={pts.join(' ')} />
-      <circle cx={last[0]} cy={last[1]} r="2.2" fill={color} />
+      <polyline fill="none" stroke="currentColor" strokeWidth="1.4" points={pts.join(' ')} />
+      <circle cx={last[0]} cy={last[1]} r="2.2" fill="currentColor" />
     </svg>
   );
 }
 
 /* -------------------------------------------------------------------- */
-/*  Pillar throughput stack chart (Team tab)                             */
+/*  Pillar throughput stack chart                                        */
 /* -------------------------------------------------------------------- */
 
-function PillarStack({ buckets }) {
-  if (!buckets || buckets.length === 0) {
+function PillarStack({ rows, pillarOrder }) {
+  if (!rows || rows.length === 0) {
     return <p className="ta-meta">No throughput data in window.</p>;
   }
+  // Aggregate weekly PRs per (week, pillar) — using the derived pillar
+  // on each row, NOT the operator-set members.pillar_id.
   const byWeek = new Map();
-  const pillars = new Set();
-  buckets.forEach((b) => {
-    pillars.add(b.pillar);
-    const k = b.week_start;
-    if (!byWeek.has(k)) byWeek.set(k, {});
-    byWeek.get(k)[b.pillar] = b.prs_merged || 0;
+  const pillarSet = new Set();
+  rows.forEach((r) => {
+    const pillar = r.derivedPillar || 'Unassigned';
+    pillarSet.add(pillar);
+    (r.week_totals || []).forEach((w) => {
+      if (!w || !w.week_start) return;
+      if (!byWeek.has(w.week_start)) byWeek.set(w.week_start, {});
+      const cell = byWeek.get(w.week_start);
+      cell[pillar] = (cell[pillar] || 0) + (w.prs_merged || 0);
+    });
   });
   const weekKeys = [...byWeek.keys()].sort();
-  const pillarList = [...pillars].sort();
+  if (weekKeys.length === 0) {
+    return <p className="ta-meta">No PRs in this window.</p>;
+  }
+  // Stable pillar order: roadmap-tab order first, then any extras (e.g.
+  // "Unassigned") alphabetically.
+  const known = pillarOrder.filter((p) => pillarSet.has(p));
+  const extras = [...pillarSet].filter((p) => !pillarOrder.includes(p)).sort();
+  const pillarList = [...known, ...extras];
+
   const stack = weekKeys.map((wk) => {
     const cell = byWeek.get(wk);
     return { week: wk, ...Object.fromEntries(pillarList.map((p) => [p, cell[p] || 0])) };
@@ -160,8 +224,7 @@ function PillarStack({ buckets }) {
 
   const W = 600, H = 240, pad = { l: 36, r: 12, t: 14, b: 36 };
   const xStep = (W - pad.l - pad.r) / Math.max(1, stack.length);
-
-  const colors = Object.fromEntries(pillarList.map((p, i) => [p, colorForPillar(p, i)]));
+  const colors = Object.fromEntries(pillarList.map((p) => [p, colorForPillar(p, pillarOrder)]));
 
   return (
     <>
@@ -216,7 +279,7 @@ function PillarStack({ buckets }) {
 }
 
 /* -------------------------------------------------------------------- */
-/*  Network density panel (Team tab)                                     */
+/*  Network density panel                                                */
 /* -------------------------------------------------------------------- */
 
 function NetworkPanel({ network }) {
@@ -225,21 +288,20 @@ function NetworkPanel({ network }) {
       <div className="ta-chartwrap--small">
         <p className="ta-fact">
           Review-network metrics need at least one PR + review in the window.
-          Once GitHub sync has populated history (and members have <code>github_login</code>
+          Once GitHub sync has populated history (and members have <code>github_login</code>{' '}
           set on their profile), this panel surfaces orphan rate, first-review p50/p90,
           and cross-pillar review percentage.
         </p>
       </div>
     );
   }
-  const under24 = formatPct(network.first_review_under_24h_pct);
-  const cross   = formatPct(network.cross_pillar_review_pct);
   return (
     <div className="ta-chartwrap--small">
       <p className="ta-fact">
-        Last 12 weeks: <strong>{under24}</strong> of PRs received their first review within 24 hours.
-        Cross-pillar review participation is <strong>{cross}</strong> — that's a
-        leading indicator of knowledge sharing, and you can slice it on the Slice tab.
+        Last 12 weeks: <strong>{formatPct(network.first_review_under_24h_pct)}</strong> of PRs
+        received their first review within 24 hours. Cross-pillar review participation is{' '}
+        <strong>{formatPct(network.cross_pillar_review_pct)}</strong> — a leading indicator of
+        knowledge sharing, sliceable on the Slice tab.
       </p>
       <div className="ta-bullets">
         <div>→ p50 first-review latency · <b>{formatHours(network.first_review_p50_hours)}</b></div>
@@ -251,7 +313,7 @@ function NetworkPanel({ network }) {
 }
 
 /* -------------------------------------------------------------------- */
-/*  Multi-line weekly trend (Member profile)                             */
+/*  Multi-line trend chart                                               */
 /* -------------------------------------------------------------------- */
 
 function TrendChart({ weeks }) {
@@ -265,9 +327,9 @@ function TrendChart({ weeks }) {
   const xOf = (i) => pad.l + i * xStep;
 
   const lines = [
-    { key: 'jira_done', color: '#2c5d75' },
-    { key: 'reviews',   color: '#b87a1a' },
-    { key: 'prs_merged',color: 'var(--ta-accent, #b8443c)' },
+    { key: 'jira_done',  color: SERIES_COLOR.jira    },
+    { key: 'reviews',    color: SERIES_COLOR.reviews },
+    { key: 'prs_merged', color: SERIES_COLOR.prs     },
   ];
 
   return (
@@ -301,16 +363,16 @@ function TrendChart({ weeks }) {
         })}
       </svg>
       <div className="ta-legend" style={{ marginTop: 6 }}>
-        <span><i style={{ background: 'var(--ta-accent, #b8443c)' }} />PRs merged</span>
-        <span><i style={{ background: '#2c5d75' }} />Jira done</span>
-        <span><i style={{ background: '#b87a1a' }} />Reviews</span>
+        <span><i style={{ background: SERIES_COLOR.prs }} />PRs merged</span>
+        <span><i style={{ background: SERIES_COLOR.jira }} />Jira done</span>
+        <span><i style={{ background: SERIES_COLOR.reviews }} />Reviews</span>
       </div>
     </>
   );
 }
 
 /* -------------------------------------------------------------------- */
-/*  Status badge (last-sync indicator)                                   */
+/*  Status badge                                                         */
 /* -------------------------------------------------------------------- */
 
 function StatusBadge({ source, info }) {
@@ -335,10 +397,10 @@ function StatusBadge({ source, info }) {
 const TABLE_COLS = [
   { key: 'name',    label: 'Member',     align: 'left',  sortable: true },
   { key: 'pillar',  label: 'Pillar',     align: 'left',  sortable: true },
-  { key: 'jira',    label: 'Jira done',  align: 'right', sortable: true, withDelta: 'jira_done' },
+  { key: 'jira',    label: 'Jira done',  align: 'right', sortable: true },
   { key: 'points',  label: 'Story pts',  align: 'right', sortable: true },
-  { key: 'prs',     label: 'PRs merged', align: 'right', sortable: true, withDelta: 'prs_merged' },
-  { key: 'reviews', label: 'Reviews',    align: 'right', sortable: true, withDelta: 'reviews' },
+  { key: 'prs',     label: 'PRs merged', align: 'right', sortable: true },
+  { key: 'reviews', label: 'Reviews',    align: 'right', sortable: true },
   { key: 'latency', label: 'Review p50', align: 'right', sortable: true },
   { key: 'spark',   label: 'PRs / wk',   align: 'left',  sortable: false },
 ];
@@ -352,7 +414,7 @@ export default function TeamAnalytics() {
   const [team, setTeam] = useState([]);
   const [status, setStatus] = useState(null);
   const [network, setNetwork] = useState(null);
-  const [pillars, setPillars] = useState([]);
+  const [basicPillars, setBasicPillars] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [reloadTick, setReloadTick] = useState(0);
@@ -366,19 +428,19 @@ export default function TeamAnalytics() {
     const load = async () => {
       try {
         setLoading(true);
-        const [membersResp, teamResp, statusResp, netResp, pillResp] = await Promise.all([
+        const [membersResp, teamResp, statusResp, netResp, basicResp] = await Promise.all([
           contributionsAPI.listMembers().catch(() => ({ members: [] })),
           contributionsAPI.team().catch(() => ({ members: [] })),
           contributionsAPI.status().catch(() => null),
           contributionsAPI.network().catch(() => null),
-          contributionsAPI.pillars().catch(() => ({ buckets: [] })),
+          roadmapAPI.getBasicData().catch(() => ({ pillars: [] })),
         ]);
         if (cancelled) return;
         setMembers(membersResp.members || []);
         setTeam(teamResp.members || []);
         setStatus(statusResp);
         setNetwork(netResp);
-        setPillars(pillResp.buckets || []);
+        setBasicPillars(basicResp?.pillars || []);
       } catch (e) {
         if (cancelled) return;
         const err = handleAPIError(e);
@@ -392,20 +454,38 @@ export default function TeamAnalytics() {
     return () => { cancelled = true; };
   }, [reloadTick]);
 
+  // Pillar sort by sequence (matches roadmap tab); stable name list
+  // for the filter pills + chart legend.
+  const orderedPillarNames = useMemo(() => {
+    const sorted = [...(basicPillars || [])].sort((a, b) => {
+      if ((a.sequence || 0) !== (b.sequence || 0)) return (a.sequence || 0) - (b.sequence || 0);
+      return (a.name || '').localeCompare(b.name || '');
+    });
+    return sorted.map((p) => p.name).filter(Boolean);
+  }, [basicPillars]);
+
+  const compToPillar = useMemo(() => buildComponentToPillar(basicPillars), [basicPillars]);
+
   const rows = useMemo(() => {
     const byID = new Map((team || []).map((t) => [t.member_id, t]));
     const merged = (members || []).map((m) => {
       const id = pick(m, 'id', 'ID');
       const t = byID.get(id) || {};
       const week_totals = t.week_totals || [];
+      const components = t.components || [];
+      const override = pick(m, 'pillar_id', 'PillarID');
+      const derivedPillar = derivePillarForMember(components, override, compToPillar);
       return {
         id,
         name: pick(m, 'display_name', 'DisplayName') || id || 'unknown',
         github: pick(m, 'github_login', 'GitHubLogin'),
         email:  pick(m, 'email', 'Email'),
         jira_account_id: pick(m, 'jira_account_id', 'JiraAccountID'),
-        pillar: pick(m, 'pillar_id', 'PillarID'),
+        pillarOverride: override,
+        derivedPillar,
+        pillar: derivedPillar || override || '',
         active: pick(m, 'active', 'Active') !== false,
+        components,
         jira:    t.jira_issues_done || 0,
         points:  t.jira_points_done || 0,
         prs:     t.prs_merged || 0,
@@ -416,10 +496,13 @@ export default function TeamAnalytics() {
     });
     (team || []).forEach((t) => {
       if (!members.find((m) => pick(m, 'id', 'ID') === t.member_id)) {
+        const components = t.components || [];
+        const derivedPillar = derivePillarForMember(components, '', compToPillar);
         merged.push({
           id: t.member_id, name: t.member_id,
           github: '', email: '', jira_account_id: '',
-          pillar: '', active: true,
+          pillarOverride: '', derivedPillar, pillar: derivedPillar,
+          active: true, components,
           jira:    t.jira_issues_done || 0,
           points:  t.jira_points_done || 0,
           prs:     t.prs_merged || 0,
@@ -430,13 +513,7 @@ export default function TeamAnalytics() {
       }
     });
     return merged;
-  }, [members, team]);
-
-  const pillarNames = useMemo(() => {
-    const set = new Set();
-    rows.forEach((r) => { if (r.pillar) set.add(r.pillar); });
-    return [...set].sort();
-  }, [rows]);
+  }, [members, team, compToPillar]);
 
   const filteredRows = useMemo(() => {
     if (pillarFilter === 'all') return rows;
@@ -534,17 +611,15 @@ export default function TeamAnalytics() {
       {empty && (
         <div className="ta-empty">
           <h3>No analytics data yet</h3>
-          <p>
-            This view shows once <code>storage.enabled</code> is on and the collector has
-            captured at least one cycle.
-          </p>
+          <p>This view shows once <code>storage.enabled</code> is on and the collector has captured at least one cycle.</p>
         </div>
       )}
 
       {!empty && tab === 'team' && (
         <TeamView
           rows={sortedRows}
-          pillarNames={pillarNames}
+          allRows={rows}
+          orderedPillarNames={orderedPillarNames}
           pillarFilter={pillarFilter}
           onPillarFilter={setPillarFilter}
           sortKey={sortKey}
@@ -552,7 +627,6 @@ export default function TeamAnalytics() {
           onSort={handleSort}
           onRowClick={openMember}
           loading={loading}
-          pillars={pillars}
           network={network}
         />
       )}
@@ -563,12 +637,13 @@ export default function TeamAnalytics() {
           onBack={() => goToTab('team')}
           onSaved={onSavedMember}
           allRows={rows}
+          orderedPillarNames={orderedPillarNames}
           onSwitchMember={openMember}
         />
       )}
 
       {!empty && tab === 'slice' && (
-        <SliceView rows={rows} />
+        <SliceView rows={rows} orderedPillarNames={orderedPillarNames} />
       )}
     </div>
   );
@@ -578,7 +653,7 @@ export default function TeamAnalytics() {
 /*  Team Overview tab                                                    */
 /* -------------------------------------------------------------------- */
 
-function TeamView({ rows, pillarNames, pillarFilter, onPillarFilter, sortKey, sortDir, onSort, onRowClick, loading, pillars, network }) {
+function TeamView({ rows, allRows, orderedPillarNames, pillarFilter, onPillarFilter, sortKey, sortDir, onSort, onRowClick, loading, network }) {
   return (
     <>
       <div className="ta-panel">
@@ -594,7 +669,7 @@ function TeamView({ rows, pillarNames, pillarFilter, onPillarFilter, sortKey, so
               className={`ta-pill${pillarFilter === 'all' ? ' is-active' : ''}`}
               onClick={() => onPillarFilter('all')}
             >All</button>
-            {pillarNames.map((p) => (
+            {orderedPillarNames.map((p) => (
               <button key={p} type="button"
                 className={`ta-pill${pillarFilter === p ? ' is-active' : ''}`}
                 onClick={() => onPillarFilter(p)}
@@ -652,7 +727,7 @@ function TeamView({ rows, pillarNames, pillarFilter, onPillarFilter, sortKey, so
                   <td className="ta-right"><span className="ta-num">{m.prs}</span><DeltaPill d={dPRs} /></td>
                   <td className="ta-right"><span className="ta-num">{m.reviews}</span><DeltaPill d={dReviews} /></td>
                   <td className="ta-right"><span className="ta-num">{formatHours(m.latency)}</span></td>
-                  <td><Spark values={sparkValues} color="var(--ta-accent, #b8443c)" /></td>
+                  <td><Spark values={sparkValues} /></td>
                 </tr>
               );
             })}
@@ -668,7 +743,7 @@ function TeamView({ rows, pillarNames, pillarFilter, onPillarFilter, sortKey, so
             <div className="ta-panel__sub">PRs merged · 12-week stack</div>
           </header>
           <div className="ta-chartwrap">
-            <PillarStack buckets={pillars} />
+            <PillarStack rows={allRows} pillarOrder={orderedPillarNames} />
           </div>
         </div>
         <div className="ta-panel">
@@ -687,7 +762,7 @@ function TeamView({ rows, pillarNames, pillarFilter, onPillarFilter, sortKey, so
 /*  Member Profile tab                                                   */
 /* -------------------------------------------------------------------- */
 
-function MemberView({ memberRow, onBack, onSaved, allRows, onSwitchMember }) {
+function MemberView({ memberRow, onBack, onSaved, allRows, orderedPillarNames, onSwitchMember }) {
   const [detail, setDetail] = useState(null);
   const [loading, setLoading] = useState(true);
   const [editGh, setEditGh] = useState('');
@@ -706,7 +781,7 @@ function MemberView({ memberRow, onBack, onSaved, allRows, onSwitchMember }) {
         if (cancelled) return;
         setDetail(d);
         setEditGh(pick(d.info, 'github_login', 'GitHubLogin') || memberRow.github || '');
-        setEditPillar(pick(d.info, 'pillar_id', 'PillarID') || memberRow.pillar || '');
+        setEditPillar(pick(d.info, 'pillar_id', 'PillarID') || memberRow.pillarOverride || '');
       } catch (e) {
         if (cancelled) return;
         toast.error(`Profile load: ${handleAPIError(e).message}`);
@@ -716,7 +791,7 @@ function MemberView({ memberRow, onBack, onSaved, allRows, onSwitchMember }) {
     };
     load();
     return () => { cancelled = true; };
-  }, [id, memberRow?.github, memberRow?.pillar]);
+  }, [id, memberRow?.github, memberRow?.pillarOverride]);
 
   if (!memberRow) {
     return (
@@ -766,6 +841,12 @@ function MemberView({ memberRow, onBack, onSaved, allRows, onSwitchMember }) {
 
   const compMax = Math.max(1, ...components.map((c) => c.issues || 0));
   const sortedRoster = [...allRows].sort((a, b) => a.name.localeCompare(b.name));
+  const pillarLabel = memberRow.pillar || 'unassigned';
+  const pillarSource = memberRow.pillarOverride
+    ? 'override'
+    : memberRow.derivedPillar
+      ? 'derived from components'
+      : 'no match';
 
   return (
     <>
@@ -777,9 +858,11 @@ function MemberView({ memberRow, onBack, onSaved, allRows, onSwitchMember }) {
         <aside className="ta-profile-card">
           <div className="ta-profile-avatar">{initialsOf(memberRow.name)}</div>
           <div className="ta-profile-name">{pick(info, 'display_name', 'DisplayName') || memberRow.name}</div>
-          <div className="ta-profile-pillar">{(memberRow.pillar || 'unassigned').toUpperCase()}</div>
+          <div className="ta-profile-pillar">{pillarLabel.toUpperCase()}{' '}<span style={{ color: 'var(--fg-faint)' }}>· {pillarSource}</span></div>
           <div className="ta-profile-handles">
-            <div>github · {memberRow.github ? `@${memberRow.github}` : <em style={{ color: 'var(--ta-fg-muted)' }}>not linked</em>}</div>
+            <div>github · {memberRow.github
+              ? <span className="gh">@{memberRow.github}</span>
+              : <em>not linked</em>}</div>
             <div>jira · {memberRow.email || pick(info, 'email', 'Email') || '—'}</div>
           </div>
           <div className="ta-kpi-grid">
@@ -794,9 +877,9 @@ function MemberView({ memberRow, onBack, onSaved, allRows, onSwitchMember }) {
           <div className="ta-card">
             <h3 className="ta-card__title">Weekly contribution
               <span className="ta-legend">
-                <span><i style={{ background: 'var(--ta-accent, #b8443c)' }} />PRs merged</span>
-                <span><i style={{ background: '#2c5d75' }} />Jira done</span>
-                <span><i style={{ background: '#b87a1a' }} />Reviews</span>
+                <span><i style={{ background: SERIES_COLOR.prs }} />PRs merged</span>
+                <span><i style={{ background: SERIES_COLOR.jira }} />Jira done</span>
+                <span><i style={{ background: SERIES_COLOR.reviews }} />Reviews</span>
               </span>
             </h3>
             <div className="ta-card__sub">Last {weeks.length || 12} weeks · counts per ISO week</div>
@@ -805,7 +888,7 @@ function MemberView({ memberRow, onBack, onSaved, allRows, onSwitchMember }) {
 
           <div className="ta-card">
             <h3 className="ta-card__title">Components touched
-              <span className="ta-legend"><span style={{ fontFamily: 'var(--ta-mono)' }}>Each row = one component · width = issues</span></span>
+              <span className="ta-meta">Each row = one component · width = issues</span>
             </h3>
             <div className="ta-card__sub">Where this member spent their work in the window</div>
             {components.length === 0 ? (
@@ -825,7 +908,7 @@ function MemberView({ memberRow, onBack, onSaved, allRows, onSwitchMember }) {
 
           <div className="ta-card">
             <h3 className="ta-card__title">This sprint
-              <span className="ta-pill" style={{ background: 'var(--ta-bg-soft)' }}>
+              <span className="ta-pill" style={{ background: 'var(--bg-sunken)' }}>
                 {sprint?.name || '—'}
               </span>
             </h3>
@@ -842,7 +925,7 @@ function MemberView({ memberRow, onBack, onSaved, allRows, onSwitchMember }) {
             <h3 className="ta-card__title">Identity
               <span className="ta-meta">edit · save triggers an aggregator rebuild</span>
             </h3>
-            <div className="ta-card__sub">Map this member to a GitHub login + pillar so PRs and review counts show up</div>
+            <div className="ta-card__sub">Map this member to a GitHub login + (optional) pillar override</div>
             <div className="ta-edit-grid">
               <label className="ta-field">
                 <span className="ta-field-label">Member ID</span>
@@ -868,12 +951,16 @@ function MemberView({ memberRow, onBack, onSaved, allRows, onSwitchMember }) {
                 <span className="ta-field-help">Empty = no GitHub link.</span>
               </label>
               <label className="ta-field">
-                <span className="ta-field-label">Pillar</span>
-                <input className="ta-input"
-                       value={editPillar}
-                       onChange={(e) => setEditPillar(e.target.value)}
-                       placeholder="essentials" />
-                <span className="ta-field-help">Free-form. Drives the Team filter pills + pillar stack chart.</span>
+                <span className="ta-field-label">Pillar override</span>
+                <select className="ta-input"
+                        value={editPillar}
+                        onChange={(e) => setEditPillar(e.target.value)}>
+                  <option value="">— derive from Jira components —</option>
+                  {orderedPillarNames.map((p) => (
+                    <option key={p} value={p}>{p}</option>
+                  ))}
+                </select>
+                <span className="ta-field-help">Empty falls back to component-derived pillar.</span>
               </label>
             </div>
             <div className="ta-form-actions">
@@ -918,7 +1005,7 @@ const SLICE_COL_AXES = [
   { val: 'quarter', label: 'Quarter' },
 ];
 
-function SliceView({ rows }) {
+function SliceView({ rows, orderedPillarNames }) {
   const [rowsAxis, setRowsAxis] = useState('pillar');
   const [colsAxis, setColsAxis] = useState('week');
   const [metric,   setMetric]   = useState('prs');
@@ -950,8 +1037,11 @@ function SliceView({ rows }) {
     }
     const set = new Set();
     rows.forEach((r) => set.add(r.pillar || 'Unassigned'));
-    return [...set].sort();
-  }, [rows, rowsAxis]);
+    // Stable ordering: roadmap-tab pillar order first, then any extras.
+    const known = orderedPillarNames.filter((p) => set.has(p));
+    const extras = [...set].filter((p) => !orderedPillarNames.includes(p)).sort();
+    return [...known, ...extras];
+  }, [rows, rowsAxis, orderedPillarNames]);
 
   const cols = useMemo(() => {
     if (colsAxis === 'week') {

--- a/roadmap-planner/frontend/src/components/TeamAnalytics.jsx
+++ b/roadmap-planner/frontend/src/components/TeamAnalytics.jsx
@@ -68,31 +68,66 @@ const initialsOf = (name) =>
 /*  Pillar derivation — same source the roadmap tab uses                 */
 /* -------------------------------------------------------------------- */
 
-// buildComponentToPillar takes the BasicPillar list from /api/basic and
-// returns a Map: lowercased component name → pillar name. Used to
-// classify members by the components they've touched.
-const buildComponentToPillar = (basicPillars) => {
+// buildComponentToPillars takes the configured pillar mapping from
+// /api/contributions/pillars (`pillars: [{name, components: []}, ...]`)
+// and returns a Map: lowercased component name → array of pillar names.
+// One component MAY map to multiple pillars (helm/trivy → CI/CD +
+// Tool Deployment). Falls back to the BasicPillar list from /api/basic
+// when the configured mapping is empty.
+const buildComponentToPillars = (configuredPillars, basicPillars) => {
   const m = new Map();
+  if (configuredPillars && configuredPillars.length) {
+    configuredPillars.forEach((p) => {
+      (p.components || []).forEach((c) => {
+        const key = (c || '').trim().toLowerCase();
+        if (!key) return;
+        const list = m.get(key) || [];
+        if (!list.includes(p.name)) list.push(p.name);
+        m.set(key, list);
+      });
+    });
+    return m;
+  }
   (basicPillars || []).forEach((p) => {
     const comp = (p.component || '').trim().toLowerCase();
-    if (comp) m.set(comp, p.name);
+    if (!comp) return;
+    const list = m.get(comp) || [];
+    if (!list.includes(p.name)) list.push(p.name);
+    m.set(comp, list);
   });
   return m;
 };
 
-// derivePillarForMember picks the pillar with the most component matches
-// from the member's component set. Falls back to the operator-set
-// override (member.pillar_id) when no match, then to ''.
-const derivePillarForMember = (memberComponents, override, compToPillar) => {
-  if (override) return override;
-  if (!memberComponents || memberComponents.length === 0) return '';
+// pillarsForMember returns the SET of pillars a member is associated
+// with, derived from their touched components. A dev who works on
+// CI/CD-tagged AND Tool Deployment-tagged components shows up under
+// both. The operator override (`override`, free-form string from the
+// `pillar_id` PATCH endpoint) is honored only when the components map
+// produced no matches — it lets the operator pin members whose work
+// doesn't surface a clear component yet.
+const pillarsForMember = (memberComponents, override, compToPillars) => {
+  const set = new Set();
+  (memberComponents || []).forEach((c) => {
+    const key = (c || '').trim().toLowerCase();
+    (compToPillars.get(key) || []).forEach((p) => set.add(p));
+  });
+  if (set.size === 0 && override) set.add(override);
+  return [...set];
+};
+
+// dominantPillar picks the single most-frequent pillar match — used
+// only for legacy single-pillar bucketing (the filter pill comparison
+// and color-of-row). The multi-tag display uses pillarsForMember.
+const dominantPillar = (memberComponents, override, compToPillars) => {
+  if (!memberComponents || memberComponents.length === 0) return override || '';
   const tally = new Map();
   memberComponents.forEach((c) => {
     const key = (c || '').trim().toLowerCase();
-    const pillar = compToPillar.get(key);
-    if (pillar) tally.set(pillar, (tally.get(pillar) || 0) + 1);
+    (compToPillars.get(key) || []).forEach((p) => {
+      tally.set(p, (tally.get(p) || 0) + 1);
+    });
   });
-  if (tally.size === 0) return '';
+  if (tally.size === 0) return override || '';
   let best = '', bestN = -1;
   for (const [p, n] of tally) {
     if (n > bestN) { best = p; bestN = n; }
@@ -188,32 +223,31 @@ function Spark({ values, width = 110, height = 28 }) {
 /*  Pillar throughput stack chart                                        */
 /* -------------------------------------------------------------------- */
 
-function PillarStack({ rows, pillarOrder }) {
-  if (!rows || rows.length === 0) {
+function PillarStack({ buckets, pillarOrder, metric = 'prs_merged' }) {
+  // Buckets come from /api/contributions/pillars: one row per (pillar, week)
+  // with prs_merged + jira_done counts already attributed by the backend's
+  // configured team_analytics.pillars map. A PR or issue spanning multiple
+  // pillars contributes once to each.
+  if (!buckets || buckets.length === 0) {
     return <p className="ta-meta">No throughput data in window.</p>;
   }
-  // Aggregate weekly PRs per (week, pillar) — using the derived pillar
-  // on each row, NOT the operator-set members.pillar_id.
   const byWeek = new Map();
   const pillarSet = new Set();
-  rows.forEach((r) => {
-    const pillar = r.derivedPillar || 'Unassigned';
-    pillarSet.add(pillar);
-    (r.week_totals || []).forEach((w) => {
-      if (!w || !w.week_start) return;
-      if (!byWeek.has(w.week_start)) byWeek.set(w.week_start, {});
-      const cell = byWeek.get(w.week_start);
-      cell[pillar] = (cell[pillar] || 0) + (w.prs_merged || 0);
-    });
+  buckets.forEach((b) => {
+    if (!b || !b.week_start) return;
+    pillarSet.add(b.pillar);
+    if (!byWeek.has(b.week_start)) byWeek.set(b.week_start, {});
+    const cell = byWeek.get(b.week_start);
+    cell[b.pillar] = (cell[b.pillar] || 0) + (b[metric] || 0);
   });
   const weekKeys = [...byWeek.keys()].sort();
   if (weekKeys.length === 0) {
     return <p className="ta-meta">No PRs in this window.</p>;
   }
-  // Stable pillar order: roadmap-tab order first, then any extras (e.g.
-  // "Unassigned") alphabetically.
-  const known = pillarOrder.filter((p) => pillarSet.has(p));
-  const extras = [...pillarSet].filter((p) => !pillarOrder.includes(p)).sort();
+  // Stable pillar order: configured order first (any zero-stack pillars
+  // still render so the legend is complete), then extras like "Unassigned".
+  const known = (pillarOrder || []).filter((p) => pillarSet.has(p));
+  const extras = [...pillarSet].filter((p) => !(pillarOrder || []).includes(p)).sort();
   const pillarList = [...known, ...extras];
 
   const stack = weekKeys.map((wk) => {
@@ -415,6 +449,7 @@ export default function TeamAnalytics() {
   const [status, setStatus] = useState(null);
   const [network, setNetwork] = useState(null);
   const [basicPillars, setBasicPillars] = useState([]);
+  const [pillarsResp, setPillarsResp] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [reloadTick, setReloadTick] = useState(0);
@@ -428,12 +463,13 @@ export default function TeamAnalytics() {
     const load = async () => {
       try {
         setLoading(true);
-        const [membersResp, teamResp, statusResp, netResp, basicResp] = await Promise.all([
+        const [membersResp, teamResp, statusResp, netResp, basicResp, pillarsR] = await Promise.all([
           contributionsAPI.listMembers().catch(() => ({ members: [] })),
           contributionsAPI.team().catch(() => ({ members: [] })),
           contributionsAPI.status().catch(() => null),
           contributionsAPI.network().catch(() => null),
           roadmapAPI.getBasicData().catch(() => ({ pillars: [] })),
+          contributionsAPI.pillars().catch(() => null),
         ]);
         if (cancelled) return;
         setMembers(membersResp.members || []);
@@ -441,6 +477,7 @@ export default function TeamAnalytics() {
         setStatus(statusResp);
         setNetwork(netResp);
         setBasicPillars(basicResp?.pillars || []);
+        setPillarsResp(pillarsR);
       } catch (e) {
         if (cancelled) return;
         const err = handleAPIError(e);
@@ -454,17 +491,26 @@ export default function TeamAnalytics() {
     return () => { cancelled = true; };
   }, [reloadTick]);
 
-  // Pillar sort by sequence (matches roadmap tab); stable name list
-  // for the filter pills + chart legend.
+  // Pillar order: prefer the configured team_analytics.pillars order (the
+  // backend's source of truth for attribution). Falls back to the roadmap
+  // tab's BasicPillar sequence ordering when no team_analytics.pillars is
+  // configured.
   const orderedPillarNames = useMemo(() => {
+    const fromConfig = pillarsResp?.order || [];
+    if (fromConfig.length > 0) return fromConfig;
     const sorted = [...(basicPillars || [])].sort((a, b) => {
       if ((a.sequence || 0) !== (b.sequence || 0)) return (a.sequence || 0) - (b.sequence || 0);
       return (a.name || '').localeCompare(b.name || '');
     });
     return sorted.map((p) => p.name).filter(Boolean);
-  }, [basicPillars]);
+  }, [pillarsResp, basicPillars]);
 
-  const compToPillar = useMemo(() => buildComponentToPillar(basicPillars), [basicPillars]);
+  // Component → pillars map. Source of truth: the backend's configured
+  // mapping (team_analytics.pillars), falling back to BasicPillar.
+  const compToPillars = useMemo(
+    () => buildComponentToPillars(pillarsResp?.pillars, basicPillars),
+    [pillarsResp, basicPillars]
+  );
 
   const rows = useMemo(() => {
     const byID = new Map((team || []).map((t) => [t.member_id, t]));
@@ -474,7 +520,8 @@ export default function TeamAnalytics() {
       const week_totals = t.week_totals || [];
       const components = t.components || [];
       const override = pick(m, 'pillar_id', 'PillarID');
-      const derivedPillar = derivePillarForMember(components, override, compToPillar);
+      const pillars = pillarsForMember(components, override, compToPillars);
+      const dom = dominantPillar(components, override, compToPillars);
       return {
         id,
         name: pick(m, 'display_name', 'DisplayName') || id || 'unknown',
@@ -482,8 +529,8 @@ export default function TeamAnalytics() {
         email:  pick(m, 'email', 'Email'),
         jira_account_id: pick(m, 'jira_account_id', 'JiraAccountID'),
         pillarOverride: override,
-        derivedPillar,
-        pillar: derivedPillar || override || '',
+        pillars,
+        pillar: dom,
         active: pick(m, 'active', 'Active') !== false,
         components,
         jira:    t.jira_issues_done || 0,
@@ -497,11 +544,12 @@ export default function TeamAnalytics() {
     (team || []).forEach((t) => {
       if (!members.find((m) => pick(m, 'id', 'ID') === t.member_id)) {
         const components = t.components || [];
-        const derivedPillar = derivePillarForMember(components, '', compToPillar);
+        const pillars = pillarsForMember(components, '', compToPillars);
+        const dom = dominantPillar(components, '', compToPillars);
         merged.push({
           id: t.member_id, name: t.member_id,
           github: '', email: '', jira_account_id: '',
-          pillarOverride: '', derivedPillar, pillar: derivedPillar,
+          pillarOverride: '', pillars, pillar: dom,
           active: true, components,
           jira:    t.jira_issues_done || 0,
           points:  t.jira_points_done || 0,
@@ -513,12 +561,12 @@ export default function TeamAnalytics() {
       }
     });
     return merged;
-  }, [members, team, compToPillar]);
+  }, [members, team, compToPillars]);
 
   const filteredRows = useMemo(() => {
     if (pillarFilter === 'all') return rows;
-    if (pillarFilter === '__unassigned') return rows.filter((r) => !r.pillar);
-    return rows.filter((r) => r.pillar === pillarFilter);
+    if (pillarFilter === '__unassigned') return rows.filter((r) => !r.pillars || r.pillars.length === 0);
+    return rows.filter((r) => (r.pillars || []).includes(pillarFilter));
   }, [rows, pillarFilter]);
 
   const sortedRows = useMemo(() => {
@@ -618,7 +666,6 @@ export default function TeamAnalytics() {
       {!empty && tab === 'team' && (
         <TeamView
           rows={sortedRows}
-          allRows={rows}
           orderedPillarNames={orderedPillarNames}
           pillarFilter={pillarFilter}
           onPillarFilter={setPillarFilter}
@@ -628,6 +675,7 @@ export default function TeamAnalytics() {
           onRowClick={openMember}
           loading={loading}
           network={network}
+          pillarBuckets={pillarsResp?.buckets || []}
         />
       )}
 
@@ -643,7 +691,11 @@ export default function TeamAnalytics() {
       )}
 
       {!empty && tab === 'slice' && (
-        <SliceView rows={rows} orderedPillarNames={orderedPillarNames} />
+        <SliceView
+          rows={rows}
+          orderedPillarNames={orderedPillarNames}
+          pillarBuckets={pillarsResp?.buckets || []}
+        />
       )}
     </div>
   );
@@ -653,7 +705,7 @@ export default function TeamAnalytics() {
 /*  Team Overview tab                                                    */
 /* -------------------------------------------------------------------- */
 
-function TeamView({ rows, allRows, orderedPillarNames, pillarFilter, onPillarFilter, sortKey, sortDir, onSort, onRowClick, loading, network }) {
+function TeamView({ rows, orderedPillarNames, pillarFilter, onPillarFilter, sortKey, sortDir, onSort, onRowClick, loading, network, pillarBuckets }) {
   return (
     <>
       <div className="ta-panel">
@@ -721,7 +773,17 @@ function TeamView({ rows, allRows, orderedPillarNames, pillarFilter, onPillarFil
                       </div>
                     </div>
                   </td>
-                  <td><span className="ta-meta">{m.pillar || '—'}</span></td>
+                  <td>
+                    {m.pillars && m.pillars.length > 0 ? (
+                      <div className="ta-pillar-tags">
+                        {m.pillars.map((p) => (
+                          <span key={p} className="ta-pillar-tag">{p}</span>
+                        ))}
+                      </div>
+                    ) : (
+                      <span className="ta-meta">—</span>
+                    )}
+                  </td>
                   <td className="ta-right"><span className="ta-num">{m.jira}</span><DeltaPill d={dJira} /></td>
                   <td className="ta-right"><span className="ta-num">{points}</span></td>
                   <td className="ta-right"><span className="ta-num">{m.prs}</span><DeltaPill d={dPRs} /></td>
@@ -743,7 +805,7 @@ function TeamView({ rows, allRows, orderedPillarNames, pillarFilter, onPillarFil
             <div className="ta-panel__sub">PRs merged · 12-week stack</div>
           </header>
           <div className="ta-chartwrap">
-            <PillarStack rows={allRows} pillarOrder={orderedPillarNames} />
+            <PillarStack buckets={pillarBuckets} pillarOrder={orderedPillarNames} />
           </div>
         </div>
         <div className="ta-panel">
@@ -841,10 +903,13 @@ function MemberView({ memberRow, onBack, onSaved, allRows, orderedPillarNames, o
 
   const compMax = Math.max(1, ...components.map((c) => c.issues || 0));
   const sortedRoster = [...allRows].sort((a, b) => a.name.localeCompare(b.name));
-  const pillarLabel = memberRow.pillar || 'unassigned';
-  const pillarSource = memberRow.pillarOverride
+  const pillarsList = (memberRow.pillars && memberRow.pillars.length > 0)
+    ? memberRow.pillars
+    : (memberRow.pillarOverride ? [memberRow.pillarOverride] : []);
+  const pillarLabel = pillarsList.length > 0 ? pillarsList.join(' · ') : 'unassigned';
+  const pillarSource = memberRow.pillarOverride && (!memberRow.pillars || memberRow.pillars.length === 0)
     ? 'override'
-    : memberRow.derivedPillar
+    : pillarsList.length > 0
       ? 'derived from components'
       : 'no match';
 
@@ -1005,16 +1070,19 @@ const SLICE_COL_AXES = [
   { val: 'quarter', label: 'Quarter' },
 ];
 
-function SliceView({ rows, orderedPillarNames }) {
+function SliceView({ rows, orderedPillarNames, pillarBuckets }) {
   const [rowsAxis, setRowsAxis] = useState('pillar');
   const [colsAxis, setColsAxis] = useState('week');
   const [metric,   setMetric]   = useState('prs');
 
+  // The set of weeks: union of (member rows' weeks) + (pillar buckets'
+  // weeks). Lets the matrix render even when one source is empty.
   const allWeeks = useMemo(() => {
-    const set = new Map();
-    rows.forEach((r) => (r.week_totals || []).forEach((w) => set.set(w.week_start, true)));
-    return [...set.keys()].sort();
-  }, [rows]);
+    const set = new Set();
+    rows.forEach((r) => (r.week_totals || []).forEach((w) => set.add(w.week_start)));
+    (pillarBuckets || []).forEach((b) => { if (b?.week_start) set.add(b.week_start); });
+    return [...set].sort();
+  }, [rows, pillarBuckets]);
 
   const seriesByMember = useMemo(() => {
     const out = new Map();
@@ -1024,6 +1092,24 @@ function SliceView({ rows, orderedPillarNames }) {
     });
     return out;
   }, [rows, allWeeks]);
+
+  // seriesByPillar parallels seriesByMember but is built from the
+  // backend's per-pillar attribution (pillarBuckets). Multi-pillar PRs /
+  // issues are already fanned out by the server, so adding cells here
+  // does not need any further fan-out.
+  const seriesByPillar = useMemo(() => {
+    const out = new Map();
+    (pillarBuckets || []).forEach((b) => {
+      if (!b?.pillar || !b.week_start) return;
+      if (!out.has(b.pillar)) out.set(b.pillar, new Map());
+      out.get(b.pillar).set(b.week_start, b);
+    });
+    const aligned = new Map();
+    out.forEach((byWeek, pillar) => {
+      aligned.set(pillar, allWeeks.map((wk) => byWeek.get(wk) || { jira_done: 0, prs_merged: 0 }));
+    });
+    return aligned;
+  }, [pillarBuckets, allWeeks]);
 
   const metricGetter = useCallback((b) => {
     if (metric === 'jira')   return b.jira_done   || 0;
@@ -1035,13 +1121,15 @@ function SliceView({ rows, orderedPillarNames }) {
     if (rowsAxis === 'member') {
       return rows.slice().sort((a, b) => a.name.localeCompare(b.name)).map((r) => r.id);
     }
-    const set = new Set();
-    rows.forEach((r) => set.add(r.pillar || 'Unassigned'));
-    // Stable ordering: roadmap-tab pillar order first, then any extras.
-    const known = orderedPillarNames.filter((p) => set.has(p));
-    const extras = [...set].filter((p) => !orderedPillarNames.includes(p)).sort();
-    return [...known, ...extras];
-  }, [rows, rowsAxis, orderedPillarNames]);
+    // Pillar axis: union of (configured order) + (pillars that actually
+    // have buckets). Empty pillars still render so the operator can see
+    // which mappings contributed nothing.
+    const set = new Set([...seriesByPillar.keys()]);
+    const known = (orderedPillarNames || []).filter((p) => set.has(p) || (orderedPillarNames || []).includes(p));
+    const fromBuckets = [...set].filter((p) => !known.includes(p)).sort();
+    const merged = [...new Set([...known, ...fromBuckets])];
+    return merged.length ? merged : (orderedPillarNames || []);
+  }, [rowsAxis, rows, orderedPillarNames, seriesByPillar]);
 
   const cols = useMemo(() => {
     if (colsAxis === 'week') {
@@ -1059,10 +1147,21 @@ function SliceView({ rows, orderedPillarNames }) {
   }, [allWeeks, colsAxis]);
 
   const matrix = useMemo(() => rowKeys.map((rk) => {
-    const matches = rowsAxis === 'member'
-      ? rows.filter((r) => r.id === rk)
-      : rows.filter((r) => (r.pillar || 'Unassigned') === rk);
     const cells = cols.map((col) => {
+      if (rowsAxis === 'pillar') {
+        const series = seriesByPillar.get(rk) || allWeeks.map(() => ({}));
+        if (colsAxis === 'week') {
+          if (metric === 'points') return 0;
+          const idx = allWeeks.indexOf(col.key);
+          if (idx < 0) return 0;
+          return metricGetter(series[idx] || {});
+        }
+        const [start, end] = col.range;
+        if (metric === 'points') return 0;
+        return series.slice(start, end).reduce((s, b) => s + metricGetter(b), 0);
+      }
+      // Member axis — sum the member's week_totals series.
+      const matches = rows.filter((r) => r.id === rk);
       if (colsAxis === 'week') {
         if (metric === 'points') return 0;
         const idx = allWeeks.indexOf(col.key);
@@ -1085,7 +1184,7 @@ function SliceView({ rows, orderedPillarNames }) {
     const max = Math.max(1, ...cells);
     const total = cells.reduce((a, b) => a + b, 0);
     return { rowKey: rk, cells, max, total };
-  }), [rowKeys, cols, rows, rowsAxis, colsAxis, metric, seriesByMember, allWeeks, metricGetter]);
+  }), [rowKeys, cols, rows, rowsAxis, colsAxis, metric, seriesByMember, seriesByPillar, allWeeks, metricGetter]);
 
   const labelOfRow = (rk) => {
     if (rowsAxis === 'member') {

--- a/roadmap-planner/frontend/src/services/api.js
+++ b/roadmap-planner/frontend/src/services/api.js
@@ -235,6 +235,26 @@ export const contributionsAPI = {
     return response.data;
   },
 
+  // Aggregate review-network density (orphan rate, p50/p90 first-review
+  // latency, cross-pillar review %). Powers the panel on the Team tab.
+  network: async (filters = {}) => {
+    const params = new URLSearchParams();
+    if (filters.from) params.set('from', filters.from);
+    if (filters.to) params.set('to', filters.to);
+    const response = await api.get(`/api/contributions/network?${params.toString()}`);
+    return response.data;
+  },
+
+  // Weekly PR-merged + Jira-done counts grouped by pillar. Powers the
+  // throughput-by-pillar stack chart on the Team tab.
+  pillars: async (filters = {}) => {
+    const params = new URLSearchParams();
+    if (filters.from) params.set('from', filters.from);
+    if (filters.to) params.set('to', filters.to);
+    const response = await api.get(`/api/contributions/pillars?${params.toString()}`);
+    return response.data;
+  },
+
   // Last-sync timestamps per source (jira / github).
   status: async () => {
     const response = await api.get('/api/contributions/status');


### PR DESCRIPTION
## Summary

Two related team-analytics improvements on one branch.

### 1. 3-tab UI matching docs/team-analytics/prototype.html

Replaces the single-page table + inline profile drawer with the prototype's full shell:

- **Team overview** — sortable table with ▲/▼/± deltas, pillar filter pills, throughput-by-pillar stack chart, review-network-density panel
- **Member profile** — sidebar identity + 4-tile KPI grid; weekly contribution multi-line chart; components-touched horizontal bars; this-sprint cluster; inline edit form (github_login + pillar); quick member-switch dropdown
- **Slice explorer** — pivot of (pillar|member) × (week|quarter) on (PRs|Jira|points) with heat-tinted cells; computed client-side from `/api/contributions/team`

URL state: `?tab=team|member|slice&member=<id>` — deep-linkable; back button works.

### 2. New backend endpoints

- `GET /api/contributions/network` — orphan rate, p50/p90 first-review latency, cross-pillar review %, # of PRs in window
- `GET /api/contributions/pillars` — weekly PR-merged + Jira-done counts grouped by member.pillar
- `GET /api/contributions/members/:id` now includes `components_touched` (top 8 Jira components by issue count) and `sprint` (WIP / Done / PRs open / PRs merged) when the member has any sprint-tagged issues

### 3. GitHub repo wildcard expansion

Pre-existing commit (rebased on top of main). Lets `github.repos: ["AlaudaDevops/*"]` enumerate the org's repos at sync time instead of needing an explicit list.

## Test plan

- [ ] CI green
- [ ] `/build-image` succeeds; tag bumped on edge cluster
- [ ] Tabs render + navigate via URL
- [ ] Pillar filter pills filter the table; `?tab=team` reflects the chosen pillar
- [ ] Click a row → Member profile loads with all four cards (trend / components / sprint / identity)
- [ ] Edit `github_login` → Save → counts repopulate after a few seconds
- [ ] Slice explorer renders for all (rows × cols × metric) combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)