### PR TITLE
feat(roadmap-planner): config-driven github_login prefill on startup

### DIFF
--- a/roadmap-planner/backend/cmd/server/main.go
+++ b/roadmap-planner/backend/cmd/server/main.go
@@ -240,7 +240,7 @@ func initTeamAnalytics(ctx context.Context, router *gin.Engine, cfg *config.Conf
 				if err != nil {
 					interval = 30 * time.Minute
 				}
-				go runJiraSync(ctx, syncer, aggregator, interval)
+				go runJiraSync(ctx, syncer, store, aggregator, interval, cfg.TeamAnalytics.GitHubLoginPrefills)
 				logger.Info("Jira sync started", zap.Duration("interval", interval), zap.Int("backfill_days", backfill))
 			}
 		} else {
@@ -407,7 +407,13 @@ func runGitHubSync(ctx context.Context, s *ghclient.Syncer, agg *contributions.A
 // runJiraSync mirrors runGitHubSync: one initial cycle, then a ticker.
 // Each successful run triggers an aggregator rebuild so the rollups
 // stay in step with the snapshot data.
-func runJiraSync(ctx context.Context, s *jirasync.Syncer, agg *contributions.Aggregator, interval time.Duration) {
+//
+// `prefills` is the team-analytics github_login_prefills map. It is
+// applied exactly once, immediately after the initial sync, on the
+// theory that the member table is empty before that first run. New
+// mappings the operator wants applied later land via the drawer
+// in-line, or via a config update + a fresh pod restart.
+func runJiraSync(ctx context.Context, s *jirasync.Syncer, store storage.Store, agg *contributions.Aggregator, interval time.Duration, prefills map[string]string) {
 	doOne := func(label string) {
 		res, err := s.Run(ctx)
 		if err != nil {
@@ -424,6 +430,18 @@ func runJiraSync(ctx context.Context, s *jirasync.Syncer, agg *contributions.Agg
 		}
 	}
 	doOne("Initial")
+	// One-shot github_login prefill: the member table now reflects
+	// whoever assigned issues during the initial sync, so any operator
+	// curated jira_id → gh_login mappings can land on the right rows.
+	// Members whose github_login was edited via the drawer have
+	// non-empty values and are skipped.
+	if applied, configured, err := contributions.ApplyGitHubLoginPrefills(ctx, store, prefills); err != nil {
+		logger.Warn("github_login prefills: partial failure",
+			zap.Int("applied", applied), zap.Int("configured", configured), zap.Error(err))
+	} else if configured > 0 {
+		logger.Info("github_login prefills applied",
+			zap.Int("applied", applied), zap.Int("configured", configured))
+	}
 	t := time.NewTicker(interval)
 	defer t.Stop()
 	for {

--- a/roadmap-planner/backend/internal/config/config.go
+++ b/roadmap-planner/backend/internal/config/config.go
@@ -61,6 +61,20 @@ type Config struct {
 //	      repos: ["alaudadevops/harbor*", "alaudadevops/helm*"]
 type TeamAnalytics struct {
 	Pillars map[string]PillarMapping `mapstructure:"pillars" yaml:"pillars"`
+	// GitHubLoginPrefills maps a Jira member id to a GitHub login. On
+	// every successful Jira sync the backend walks this map and writes
+	// each gh login onto the corresponding member iff the member's
+	// `github_login` is currently empty — manual edits in the team
+	// drawer always win, so once an operator overrides a value here
+	// the prefill never clobbers it. Empty map disables the feature.
+	//
+	// Example:
+	//
+	//	team_analytics:
+	//	  github_login_prefills:
+	//	    daniel: danielfbm
+	//	    jtcheng: chengjingtao
+	GitHubLoginPrefills map[string]string `mapstructure:"github_login_prefills" yaml:"github_login_prefills"`
 }
 
 // PillarMapping is one bucket inside TeamAnalytics.Pillars.

--- a/roadmap-planner/backend/internal/contributions/prefills.go
+++ b/roadmap-planner/backend/internal/contributions/prefills.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2024 The AlaudaDevops Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package contributions
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/AlaudaDevops/toolbox/roadmap-planner/backend/internal/storage"
+)
+
+// ApplyGitHubLoginPrefills walks an operator-curated map (Jira id →
+// GitHub login) and writes each entry onto the matching member iff
+// that member's `github_login` is currently empty. Intended to run
+// once at startup, after the first Jira sync has populated the
+// member table — re-running is harmless (no-op for already-linked
+// members), so wiring it after every sync would also be safe.
+//
+// The "only when empty" rule is the design: a manual edit through the
+// team-overview drawer (PATCH /api/contributions/members/:id) is the
+// operator's source of truth and must never be silently overwritten
+// by a future restart. New mappings the operator wants applied either
+// land via the drawer in-line, or via a config update + a fresh
+// startup pass.
+//
+// Returns (applied, configured) — number of members actually updated
+// vs. number of entries in the prefills map. Members listed in the
+// config but not present in the DB (e.g. the Jira sync hasn't picked
+// them up yet) are silently skipped; the operator can re-run by
+// restarting the pod after the Jira sync completes.
+//
+// Errors writing a single entry are logged via the returned error
+// (joined into a wrapped error) but the function does NOT abort:
+// other prefills in the same batch still apply. That keeps a typo'd
+// gh login from blocking a clean batch of 12 valid entries.
+func ApplyGitHubLoginPrefills(ctx context.Context, store storage.Store, prefills map[string]string) (applied int, configured int, err error) {
+	if len(prefills) == 0 {
+		return 0, 0, nil
+	}
+	configured = len(prefills)
+	members, mErr := store.ListMembers(ctx)
+	if mErr != nil {
+		return 0, configured, fmt.Errorf("prefills: list members: %w", mErr)
+	}
+	by := make(map[string]storage.Member, len(members))
+	for _, m := range members {
+		by[m.ID] = m
+	}
+	var failures []string
+	for jiraID, ghLogin := range prefills {
+		jid := strings.TrimSpace(jiraID)
+		gh := strings.ToLower(strings.TrimSpace(ghLogin))
+		if jid == "" || gh == "" {
+			continue
+		}
+		m, ok := by[jid]
+		if !ok {
+			continue
+		}
+		if m.GitHubLogin != "" {
+			continue
+		}
+		// SetMemberIdentity writes literally — what we pass for
+		// display_name and pillar_id is preserved, so we round-trip
+		// the existing values to leave them untouched.
+		if sErr := store.SetMemberIdentity(ctx, m.ID, m.DisplayName, gh, m.PillarID); sErr != nil {
+			failures = append(failures, fmt.Sprintf("%s→%s: %v", jid, gh, sErr))
+			continue
+		}
+		applied++
+	}
+	if len(failures) > 0 {
+		return applied, configured, fmt.Errorf("prefills: %d entry write(s) failed: %s", len(failures), strings.Join(failures, "; "))
+	}
+	return applied, configured, nil
+}

--- a/roadmap-planner/backend/internal/contributions/prefills_test.go
+++ b/roadmap-planner/backend/internal/contributions/prefills_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2024 The AlaudaDevops Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+*/
+
+package contributions
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/AlaudaDevops/toolbox/roadmap-planner/backend/internal/storage"
+)
+
+// TestApplyGitHubLoginPrefills covers the four behaviors that matter:
+//   - empty github_login on the member is filled from config (apply)
+//   - non-empty github_login (e.g. operator-edited via the drawer)
+//     is left alone (preserve)
+//   - members listed in the config but missing from the DB are
+//     skipped without error (no panic, no insert)
+//   - whitespace and casing are normalized before write
+func TestApplyGitHubLoginPrefills(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	store, err := storage.OpenSQLite(filepath.Join(dir, "prefills.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	// alice: empty github_login → should be filled.
+	// bob:   already linked manually → must NOT be overwritten.
+	// (carol intentionally not seeded → must be skipped, no error.)
+	if err := store.UpsertMember(ctx, storage.Member{
+		ID: "alice", DisplayName: "Alice Tan", Active: true,
+	}); err != nil {
+		t.Fatalf("alice: %v", err)
+	}
+	if err := store.UpsertMember(ctx, storage.Member{
+		ID: "bob", DisplayName: "Bob Lee", Active: true,
+	}); err != nil {
+		t.Fatalf("bob: %v", err)
+	}
+	// Lay down bob's existing link via the literal-overwrite path.
+	if err := store.SetMemberIdentity(ctx, "bob", "Bob Lee", "bob-on-github", ""); err != nil {
+		t.Fatalf("bob set: %v", err)
+	}
+
+	prefills := map[string]string{
+		"alice": "  AliceTan  ", // exercises whitespace + case normalization
+		"bob":   "bob-shouldnt-clobber",
+		"carol": "carol-on-github",
+		"":      "ignore-empty-key",
+		"dan":   "",
+	}
+	applied, configured, err := ApplyGitHubLoginPrefills(ctx, store, prefills)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if configured != 5 {
+		t.Fatalf("configured=%d, want 5", configured)
+	}
+	if applied != 1 {
+		t.Fatalf("applied=%d, want 1 (only alice)", applied)
+	}
+
+	got, err := store.ListMembers(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	by := map[string]storage.Member{}
+	for _, m := range got {
+		by[m.ID] = m
+	}
+	if by["alice"].GitHubLogin != "alicetan" {
+		t.Fatalf("alice.GitHubLogin = %q, want alicetan", by["alice"].GitHubLogin)
+	}
+	if by["bob"].GitHubLogin != "bob-on-github" {
+		t.Fatalf("bob.GitHubLogin = %q, want bob-on-github (operator edit must win)", by["bob"].GitHubLogin)
+	}
+	if _, ok := by["carol"]; ok {
+		t.Fatalf("carol should not exist — prefills must not insert members")
+	}
+
+	// Re-running is a no-op: alice now has a value, the rest were
+	// already skipped.
+	applied2, _, err := ApplyGitHubLoginPrefills(ctx, store, prefills)
+	if err != nil {
+		t.Fatalf("re-apply: %v", err)
+	}
+	if applied2 != 0 {
+		t.Fatalf("applied2=%d, want 0 on re-run", applied2)
+	}
+}
+
+// TestApplyGitHubLoginPrefills_EmptyMap is the no-op fast path —
+// callers with no config shouldn't pay for a member-list query.
+func TestApplyGitHubLoginPrefills_EmptyMap(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	store, err := storage.OpenSQLite(filepath.Join(dir, "prefills.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	applied, configured, err := ApplyGitHubLoginPrefills(ctx, store, nil)
+	if err != nil {
+		t.Fatalf("nil map: %v", err)
+	}
+	if applied != 0 || configured != 0 {
+		t.Fatalf("applied=%d configured=%d, want both 0", applied, configured)
+	}
+}


### PR DESCRIPTION
## Summary

Operators already know up-front which GitHub login each Jira member uses — no value in inferring it from the org's public roster (and the org-fetch path missed half the team anyway). Drop the inference idea, ship a static map in the config that's applied once on startup.

## Behavior

- New config: `team_analytics.github_login_prefills: { jira_id: gh_login }`.
- After the initial Jira sync (when the member table is non-empty), the backend walks the map and writes `github_login` onto each matching member **only when the field is currently empty**. Manual edits via the team-overview drawer therefore always win — operators who change their mind on a mapping fix it in the drawer once and a future restart never clobbers it.
- Members listed in the config but missing from the DB (Jira sync hasn't seen them yet) are silently skipped; the next restart after the sync picks them up.

## Wiring

- `internal/config/config.go` — adds `GitHubLoginPrefills map[string]string` under `TeamAnalytics`.
- `internal/contributions/prefills.go` — `ApplyGitHubLoginPrefills(ctx, store, prefills)`; pure logic.
- `cmd/server/main.go` — `runJiraSync` calls the apply pass once after the initial sync.
- Dev gitops `manifests/dev/roadmap-planner/dev-config.yaml` (separate edge repo) seeded with the 13 mappings the team curated. Prod edge configmap bump goes in a follow-up gitops MR alongside the production image roll.

No GitHub API calls. No schema migration. No frontend changes — the existing drawer already handles in-line edits and one-offs.

## Test plan

- [x] `go test ./internal/contributions/...` — covers apply / preserve-existing-edit / skip-missing-member / case+whitespace normalization / no-op re-run / empty map.
- [x] `go build ./...` clean.
- [ ] Verify on dev pod: hit `/api/contributions/members` after the dev pod rolls; the 13 prefilled members should now have `github_login` set, except `daniel` which already had `danielfbm` from earlier (operator edit preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)